### PR TITLE
Deal with duplicate errors more gracefully

### DIFF
--- a/operations_simulator/plumbing/invalid_reasons.py
+++ b/operations_simulator/plumbing/invalid_reasons.py
@@ -35,3 +35,21 @@ class InvalidTeq(PlumbingInvalidReason):
     state_id: str
     edge_id: Tuple
     teq: int
+
+
+@dataclass(frozen=True)
+class DuplicateError(PlumbingInvalidReason):
+    original_error: PlumbingInvalidReason
+
+
+def multi_error_msg(error_msg):
+    message = "Multiple instances of this error were detected:\n"\
+        + error_msg + "\n"\
+        + "Consider checking for errors in the mapping dict."
+    return message
+
+
+def add_error(error, error_set):
+    if error in error_set:
+        error = DuplicateError(multi_error_msg(error.error_message), error)
+    error_set.add(error)

--- a/operations_simulator/plumbing/invalid_reasons.py
+++ b/operations_simulator/plumbing/invalid_reasons.py
@@ -2,34 +2,34 @@ from dataclasses import dataclass
 from typing import Tuple
 
 
-@dataclass
+@dataclass(frozen=True)
 class PlumbingInvalidReason:
     error_message: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidComponentName(PlumbingInvalidReason):
     component_name: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidStateName(PlumbingInvalidReason):
     component_name: str
     state_id: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidComponentNode(PlumbingInvalidReason):
     component_name: str
     node_name: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidNodePressure(PlumbingInvalidReason):
     node_name: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidTeq(PlumbingInvalidReason):
     component_name: str
     state_id: str

--- a/operations_simulator/plumbing/plumbing_component.py
+++ b/operations_simulator/plumbing/plumbing_component.py
@@ -14,7 +14,7 @@ class PlumbingComponent:
         self.component_graph = nx.MultiDiGraph(edge_list)
         self.states = copy.deepcopy(states)
         self.current_state = None
-        self.error_list = []
+        self.error_set = set()
 
         # Convert provided teq values into FC values
         for state_id, state in self.states.items():
@@ -27,18 +27,17 @@ class PlumbingComponent:
                         error = invalid.InvalidTeq(
                             f"Invalid provided teq value ('{state[edge]}'), accepted keyword is: "
                             f"'{utils.CLOSED_KEYWORD}'", self.name, state_id, edge, og_teq)
-                        self.error_list.append(error)
+                        self.error_set.add(error)
                         state[edge] = utils.CLOSED_KEYWORD
 
-                # TODO(jacob/wendi): Look into eventually implementing
-                # this with datetime.timedelta object.
+                # TODO(jacob/wendi): Look into eventually implementing this with datetime.timedelta.
                 state[edge] = utils.teq_to_FC(state[edge])
 
                 if state[edge] > utils.FC_MAX:
                     error = invalid.InvalidTeq(
                         "Provided teq value too low, minimum value is: "
                         f"{utils.micros_to_s(utils.TEQ_MIN)}s", self.name, state_id, edge, og_teq)
-                    self.error_list.append(error)
+                    self.error_set.add(error)
                     state[edge] = utils.FC_MAX
 
-        self.valid = len(self.error_list) == 0
+        self.valid = len(self.error_set) == 0

--- a/operations_simulator/plumbing/plumbing_engine.py
+++ b/operations_simulator/plumbing/plumbing_engine.py
@@ -40,39 +40,28 @@ class PlumbingEngine:
             if nodes_map is None:
                 error = invalid.InvalidComponentName(
                     f"Component with name '{name}' not found in provided mapping dict.", name)
-                if error in self.error_set:
-                    error = invalid.InvalidComponentName(
-                        utils.multi_error_msg(
-                            "Component with name '{name}' not found in provided mapping dict."),
-                        name)
-
-                self.error_set.add(error)
+                invalid.add_error(error, self.error_set)
                 continue
 
             for start_node, end_node, edge_key in component_graph.edges(keys=True):
                 both_nodes_valid = True
 
                 if nodes_map.get(start_node) is None:
-                    node = start_node
+                    error = invalid.InvalidComponentNode(
+                        f"Component '{name}', node {start_node} not found in mapping dict.",
+                        name, start_node)
+                    invalid.add_error(error, self.error_set)
                     both_nodes_valid = False
                 if nodes_map.get(end_node) is None:
-                    node = end_node
+                    error = invalid.InvalidComponentNode(
+                        f"Component '{name}', node {end_node} not found in mapping dict.",
+                        name, end_node)
+                    invalid.add_error(error, self.error_set)
                     both_nodes_valid = False
 
                 if both_nodes_valid:
                     self.plumbing_graph.add_edge(
                         nodes_map[start_node], nodes_map[end_node], edge_key)
-                else:
-                    error = invalid.InvalidComponentNode(
-                        f"Component '{name}', node {node} not found in mapping dict.",
-                        name, node)
-                    if error in self.error_set:
-                        error = invalid.InvalidComponentNode(
-                            utils.multi_error_msg(
-                                f"Component '{name}', node {node} not found in mapping dict."),
-                            name, node)
-
-                    self.error_set.add(error)
 
         # Set a time resolution based on lowest teq (highest FC) if graph isn't empty
         if not nx.classes.function.is_empty(self.plumbing_graph):
@@ -131,26 +120,21 @@ class PlumbingEngine:
 
             both_nodes_valid = True
             if component_map.get(cstart_node) is None:
-                node = cstart_node
+                error = invalid.InvalidComponentNode(
+                    f"Component '{component.name}', node {cstart_node} not found in mapping dict.",
+                    component.name, cstart_node)
+                invalid.add_error(error, self.error_set)
                 both_nodes_valid = False
             if component_map.get(cend_node) is None:
-                node = cend_node
+                error = invalid.InvalidComponentNode(
+                    f"Component '{component.name}', node {cend_node} not found in mapping dict.",
+                    component.name, cend_node)
+                invalid.add_error(error, self.error_set)
                 both_nodes_valid = False
 
             if both_nodes_valid:
                 new_edge = (component_map[cstart_node], component_map[cend_node], key)
                 state_edges_graph[new_edge] = state_edges_component[cedge]
-            else:
-                error = invalid.InvalidComponentNode(
-                    f"Component '{component.name}', node {node} not found in mapping dict.",
-                    component.name, node)
-                if error in self.error_set:
-                    error = invalid.InvalidComponentNode(
-                        utils.multi_error_msg(
-                            f"Component '{component.name}', node {node} not found in mapping dict."),
-                            component.name, node)
-
-                self.error_set.add(error)
 
         # Set FC on main graph according to new dict
         nx.classes.function.set_edge_attributes(self.plumbing_graph, state_edges_graph, 'FC')

--- a/operations_simulator/plumbing/plumbing_utils.py
+++ b/operations_simulator/plumbing/plumbing_utils.py
@@ -29,10 +29,3 @@ def micros_to_s(micros):
 
 def s_to_micros(sec):
     return sec * 1e6
-
-
-def multi_error_msg(error):
-    message = "Multiple instances of this error were detected:\n"\
-        + error + "\n"\
-        + "Consider checking for errors in the mapping dict."
-    return message

--- a/operations_simulator/plumbing/plumbing_utils.py
+++ b/operations_simulator/plumbing/plumbing_utils.py
@@ -29,3 +29,10 @@ def micros_to_s(micros):
 
 def s_to_micros(sec):
     return sec * 1e6
+
+
+def multi_error_msg(error):
+    message = "Multiple instances of this error were detected:\n"\
+        + error + "\n"\
+        + "Consider checking for errors in the mapping dict."
+    return message

--- a/operations_simulator/plumbing/tests/test_plumbing_engine.py
+++ b/operations_simulator/plumbing/tests/test_plumbing_engine.py
@@ -175,33 +175,24 @@ def test_missing_component():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.valid
-    assert len(plumb.error_list) == 2
+    assert len(plumb.error_set) == 2
 
-    error1 = plumb.error_list[0]
-    assert isinstance(error1, invalid.InvalidComponentName)
-    assert error1.component_name == wrong_component_name
-    assert error1.error_message ==\
-        f"Component with name '{wrong_component_name}' not found in provided mapping dict."
+    error1 = invalid.InvalidComponentName(
+        f"Component with name '{wrong_component_name}' not found in provided mapping dict.",
+        wrong_component_name)
 
-    error2 = plumb.error_list[1]
-    assert isinstance(error2, invalid.InvalidComponentName)
-    assert error2.component_name == wrong_component_name
-    assert error2.error_message ==\
-        f"Component '{wrong_component_name}' state not found in initial states dict."
+    error2 = invalid.InvalidComponentName(
+        f"Component '{wrong_component_name}' state not found in initial states dict.",
+        wrong_component_name)
+
+    assert error1 in plumb.error_set
+    assert error2 in plumb.error_set
 
 
 def test_wrong_node_mapping():
     # The node name should be 1.
     proper_node_name = 1
     wrong_node_name = 5
-
-    # Since the node name is wrong in the mapping, an error should be added
-    # every time the mapping dict is accessed to find the matching graph node.
-    # This translates to twice (once per component) when populating the main graph,
-    # and twice (once per component) when assigning initial states by component,
-    # since the component node stored in the component's states dict needs to be
-    # translated into a main graph node. So 4 errors total.
-    total_call_num = 4
     pc1 = create_component(0, 0, 0, 0, 'valve1', 'A')
     pc2 = create_component(0, 0, 0, 0, 'valve2', 'B')
 
@@ -222,13 +213,27 @@ def test_wrong_node_mapping():
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.valid
-    assert len(plumb.error_list) == total_call_num
-    for error in plumb.error_list:
-        assert isinstance(error, invalid.InvalidComponentNode)
-        assert error.error_message ==\
-            f"Component 'valve1', node {proper_node_name} not found in mapping dict."
-        assert error.component_name == 'valve1'
-        assert error.node_name == proper_node_name
+
+    # Since the node name is wrong in the mapping, an error should be added
+    # every time the mapping dict is accessed to find the matching graph node.
+    # This translates to twice (once per component) when populating the main graph,
+    # and twice (once per component) when assigning initial states by component,
+    # since the component node stored in the component's states dict needs to be
+    # translated into a main graph node. So 4 errors total, but they're identical
+    # so we should get one original error and one multi-error note.
+    assert len(plumb.error_set) == 2
+
+    error = invalid.InvalidComponentNode(
+        f"Component 'valve1', node {proper_node_name} not found in mapping dict.",
+        'valve1', proper_node_name)
+
+    duplicate_error = invalid.InvalidComponentNode(
+        utils.multi_error_msg(
+            f"Component 'valve1', node {proper_node_name} not found in mapping dict."),
+        'valve1', proper_node_name)
+
+    assert error in plumb.error_set
+    assert duplicate_error in plumb.error_set
 
 
 def test_missing_node_pressure():
@@ -253,13 +258,12 @@ def test_missing_node_pressure():
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.valid
-    assert len(plumb.error_list) == 1
+    assert len(plumb.error_set) == 1
 
-    error = plumb.error_list[0]
-    assert isinstance(error, invalid.InvalidNodePressure)
-    assert error.error_message ==\
-        f"Node {wrong_node_name} not found in initial node pressures dict."
-    assert error.node_name == wrong_node_name
+    error = invalid.InvalidNodePressure(
+        f"Node {wrong_node_name} not found in initial node pressures dict.", wrong_node_name)
+
+    assert error in plumb.error_set
 
 
 def test_missing_initial_state():
@@ -285,13 +289,41 @@ def test_missing_initial_state():
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.valid
-    assert len(plumb.error_list) == 1
+    assert len(plumb.error_set) == 1
 
-    error = plumb.error_list[0]
-    assert isinstance(error, invalid.InvalidComponentName)
-    assert error.error_message ==\
-        f"Component '{proper_component_name}' state not found in initial states dict."
-    assert error.component_name == proper_component_name
+    error = invalid.InvalidComponentName(
+        f"Component '{proper_component_name}' state not found in initial states dict.",
+        proper_component_name)
+
+    assert error in plumb.error_set
+
+
+def test_error_reset():
+    wrong_component_name = 'potato'
+    pc1 = create_component(0, 0, 0, 0, 'valve1', 'A')
+    pc2 = create_component(0, 0, 0, 0, 'valve2', 'B')
+
+    component_mapping = {
+        'valve1': {
+            1: 1,
+            2: 2
+        },
+        'valve2': {
+            1: 2,
+            2: 3
+        }
+    }
+
+    pressures = {3: 100}
+    default_states = {'valve1': 'closed', 'valve2': 'open'}
+    plumb = ops.PlumbingEngine(
+        {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
+
+    assert not plumb.valid
+
+    plumb = ops.PlumbingEngine()
+
+    assert plumb.valid
 
 
 def test_set_component_wrong_state_name():

--- a/operations_simulator/plumbing/tests/test_plumbing_engine.py
+++ b/operations_simulator/plumbing/tests/test_plumbing_engine.py
@@ -227,10 +227,8 @@ def test_wrong_node_mapping():
         f"Component 'valve1', node {proper_node_name} not found in mapping dict.",
         'valve1', proper_node_name)
 
-    duplicate_error = invalid.InvalidComponentNode(
-        utils.multi_error_msg(
-            f"Component 'valve1', node {proper_node_name} not found in mapping dict."),
-        'valve1', proper_node_name)
+    duplicate_error = invalid.DuplicateError(invalid.multi_error_msg(
+        f"Component 'valve1', node {proper_node_name} not found in mapping dict."), error)
 
     assert error in plumb.error_set
     assert duplicate_error in plumb.error_set


### PR DESCRIPTION
The error list is now an error set to prevent the user being inundated
by a ton of repeated instances caused by the same error. Instead, if
an identical duplicate is detected, a single "note" error is added to
the error set to indicate there were multiple occurrences of this error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/operations-simulator/9)
<!-- Reviewable:end -->
