### PR TITLE
Add better error catching for components

### DIFF
--- a/topside/plumbing/invalid_reasons.py
+++ b/topside/plumbing/invalid_reasons.py
@@ -25,6 +25,11 @@ class InvalidComponentNode(PlumbingInvalidReason):
 
 
 @dataclass(frozen=True)
+class InvalidComponentEdge(PlumbingInvalidReason):
+    edge: tuple
+
+
+@dataclass(frozen=True)
 class InvalidNodePressure(PlumbingInvalidReason):
     node_name: str
 
@@ -33,7 +38,7 @@ class InvalidNodePressure(PlumbingInvalidReason):
 class InvalidTeq(PlumbingInvalidReason):
     component_name: str
     state_id: str
-    edge_id: Tuple
+    edge_id: tuple
     teq: int
 
 

--- a/topside/plumbing/plumbing_component.py
+++ b/topside/plumbing/plumbing_component.py
@@ -16,6 +16,15 @@ class PlumbingComponent:
         self.current_state = None
         self.error_set = set()
 
+        edge_set = set()
+        for edge in edge_list:
+            last_len = len(edge_set)
+            edge_set.add(edge)
+            if len(edge_set) == last_len:
+                error = invalid.InvalidComponentEdge(
+                    f"Duplicate edges '{edge}' found in edge list.", edge)
+                invalid.add_error(error, self.error_set)
+
         # Convert provided teq values into FC values
         for state_id, state in self.states.items():
             for edge in state:

--- a/topside/plumbing/plumbing_component.py
+++ b/topside/plumbing/plumbing_component.py
@@ -56,5 +56,5 @@ class PlumbingComponent:
     def is_valid(self):
         return len(self.error_set) == 0
 
-    def list_errors(self):
+    def errors(self):
         return self.error_set

--- a/topside/plumbing/plumbing_component.py
+++ b/topside/plumbing/plumbing_component.py
@@ -18,12 +18,11 @@ class PlumbingComponent:
 
         edge_set = set()
         for edge in edge_list:
-            last_len = len(edge_set)
-            edge_set.add(edge)
-            if len(edge_set) == last_len:
+            if edge in edge_set:
                 error = invalid.InvalidComponentEdge(
                     f"Duplicate edges '{edge}' found in edge list.", edge)
                 invalid.add_error(error, self.error_set)
+            edge_set.add(edge)
 
         # Convert provided teq values into FC values
         for state_id, state in self.states.items():

--- a/topside/plumbing/plumbing_component.py
+++ b/topside/plumbing/plumbing_component.py
@@ -19,6 +19,11 @@ class PlumbingComponent:
         # Convert provided teq values into FC values
         for state_id, state in self.states.items():
             for edge in state:
+                if edge not in edge_list:
+                    error = invalid.InvalidComponentEdge(
+                        f"Edge '{edge}' not found in provided edge list.", edge)
+                    invalid.add_error(error, self.error_set)
+                    continue
                 og_teq = state[edge]
                 if isinstance(state[edge], (float, int)):
                     state[edge] = int(utils.s_to_micros(state[edge]))
@@ -27,7 +32,7 @@ class PlumbingComponent:
                         error = invalid.InvalidTeq(
                             f"Invalid provided teq value ('{state[edge]}'), accepted keyword is: "
                             f"'{utils.CLOSED_KEYWORD}'", self.name, state_id, edge, og_teq)
-                        self.error_set.add(error)
+                        invalid.add_error(error, self.error_set)
                         state[edge] = utils.CLOSED_KEYWORD
 
                 # TODO(jacob/wendi): Look into eventually implementing this with datetime.timedelta.
@@ -37,7 +42,8 @@ class PlumbingComponent:
                     error = invalid.InvalidTeq(
                         "Provided teq value too low, minimum value is: "
                         f"{utils.micros_to_s(utils.TEQ_MIN)}s", self.name, state_id, edge, og_teq)
-                    self.error_set.add(error)
+                    invalid.add_error(error, self.error_set)
                     state[edge] = utils.FC_MAX
 
-        self.valid = len(self.error_set) == 0
+    def is_valid(self):
+        return len(self.error_set) == 0

--- a/topside/plumbing/plumbing_component.py
+++ b/topside/plumbing/plumbing_component.py
@@ -56,3 +56,6 @@ class PlumbingComponent:
 
     def is_valid(self):
         return len(self.error_set) == 0
+
+    def list_errors(self):
+        return self.error_set

--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -382,3 +382,12 @@ class PlumbingEngine:
                     f"'{arg}' not found as component name or edge identifier.")
 
         return ret
+
+    def list_errors(self):
+        return self.error_set
+
+    def list_nodes(self, data=True):
+        return list(self.plumbing_graph.nodes(data=data))
+
+    def list_edges(self, data=True):
+        return list(self.plumbing_graph.edges(keys=True, data=data))

--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -35,6 +35,12 @@ class PlumbingEngine:
         initial_states = copy.deepcopy(initial_states)
 
         for name, component in self.component_dict.items():
+            if not component.is_valid():
+                error = invalid.InvalidComponentName(
+                    f"Component with name '{name}' is not valid;"
+                    " component cannot be loaded in until errors are resolved.", name)
+                invalid.add_error(error, self.error_set)
+                continue
             name_valid = True
             if name not in self.mapping:
                 error = invalid.InvalidComponentName(
@@ -126,6 +132,10 @@ class PlumbingEngine:
 
     def add_component(self, component, mapping, state_id, pressures=None, fail_silently=False):
         '''Adds a component to the main plumbing graph according to provided specifications'''
+        if not fail_silently and not component.is_valid():
+            raise exceptions.BadInputError(
+                "Component not valid; all errors must be resolved before loading in.")
+
         if not pressures:
             pressures = {}
 

--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -383,11 +383,11 @@ class PlumbingEngine:
 
         return ret
 
-    def list_errors(self):
+    def errors(self):
         return self.error_set
 
-    def list_nodes(self, data=True):
+    def nodes(self, data=True):
         return list(self.plumbing_graph.nodes(data=data))
 
-    def list_edges(self, data=True):
+    def edges(self, data=True):
         return list(self.plumbing_graph.edges(keys=True, data=data))

--- a/topside/plumbing/tests/test_plumbing_component.py
+++ b/topside/plumbing/tests/test_plumbing_component.py
@@ -75,6 +75,28 @@ def test_invalid_keyword():
     assert error in pc.error_set
 
 
+def test_duplicate_edges():
+    states = {
+        'open': {
+            (1, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        },
+        'closed': {
+            (1, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        }
+    }
+    edge = (1, 2, 'A1')
+    edges = [edge, edge, (2, 1, 'A2')]
+
+    pc = top.PlumbingComponent('valve', states, edges)
+
+    assert not pc.is_valid()
+
+    error = invalid.InvalidComponentEdge(f"Duplicate edges '{edge}' found in edge list.", edge)
+    assert error in pc.error_set
+
+
 def test_edge_id_error():
     wrong_node = 5
 

--- a/topside/plumbing/tests/test_plumbing_component.py
+++ b/topside/plumbing/tests/test_plumbing_component.py
@@ -41,7 +41,7 @@ def test_plumbing_component_setup():
         }
     }
     assert pc1.is_valid()
-    assert not pc1.list_errors()
+    assert not pc1.errors()
 
 
 def test_minimum_teq():
@@ -51,12 +51,12 @@ def test_minimum_teq():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.list_errors()) == 1
+    assert len(pc.errors()) == 1
 
     error = invalid.InvalidTeq(
         f'Provided teq value too low, minimum value is: {utils.micros_to_s(utils.TEQ_MIN)}s',
         'valve', 'closed', (2, 1, 'A2'), teq_too_low)
-    assert error in pc.list_errors()
+    assert error in pc.errors()
 
 
 def test_invalid_keyword():
@@ -66,13 +66,13 @@ def test_invalid_keyword():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.list_errors()) == 1
+    assert len(pc.errors()) == 1
 
     error = invalid.InvalidTeq(
         f"Invalid provided teq value ('potato'), accepted keyword is: '{utils.CLOSED_KEYWORD}'",
         'valve', 'closed', (2, 1, 'A2'), wrong_keyword_teq)
 
-    assert error in pc.list_errors()
+    assert error in pc.errors()
 
 
 def test_duplicate_edges():
@@ -94,7 +94,7 @@ def test_duplicate_edges():
     assert not pc.is_valid()
 
     error = invalid.InvalidComponentEdge(f"Duplicate edges '{edge}' found in edge list.", edge)
-    assert error in pc.list_errors()
+    assert error in pc.errors()
 
 
 def test_edge_id_error():
@@ -117,7 +117,7 @@ def test_edge_id_error():
     assert not pc.is_valid()
     error = invalid.InvalidComponentEdge(
         f"Edge '({wrong_node}, 2, 'A1')' not found in provided edge list.", (wrong_node, 2, 'A1'))
-    assert error in pc.list_errors()
+    assert error in pc.errors()
 
 
 def test_multiple_errors():
@@ -128,7 +128,7 @@ def test_multiple_errors():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.list_errors()) == 2
+    assert len(pc.errors()) == 2
 
     error1 = invalid.InvalidTeq(
         f"Provided teq value too low, minimum value is: {utils.micros_to_s(utils.TEQ_MIN)}s",
@@ -139,8 +139,8 @@ def test_multiple_errors():
         f" accepted keyword is: '{utils.CLOSED_KEYWORD}'",
         'valve', 'closed', (2, 1, 'A2'), wrong_keyword_teq)
 
-    assert error1 in pc.list_errors()
-    assert error2 in pc.list_errors()
+    assert error1 in pc.errors()
+    assert error2 in pc.errors()
 
 
 def test_component_dicts_remain_unchanged():

--- a/topside/plumbing/tests/test_plumbing_component.py
+++ b/topside/plumbing/tests/test_plumbing_component.py
@@ -40,7 +40,7 @@ def test_plumbing_component_setup():
             (2, 1, 'A2'): 0
         }
     }
-    assert pc1.valid
+    assert pc1.is_valid()
     assert not pc1.error_set
 
 
@@ -50,7 +50,7 @@ def test_minimum_teq():
     states, edges = two_edge_states_edges(normal_teq, normal_teq, normal_teq, teq_too_low)
     pc = top.PlumbingComponent('valve', states, edges)
 
-    assert not pc.valid
+    assert not pc.is_valid()
     assert len(pc.error_set) == 1
 
     error = invalid.InvalidTeq(
@@ -65,13 +65,36 @@ def test_invalid_keyword():
     states, edges = two_edge_states_edges(normal_teq, normal_teq, normal_teq, wrong_keyword_teq)
     pc = top.PlumbingComponent('valve', states, edges)
 
-    assert not pc.valid
+    assert not pc.is_valid()
     assert len(pc.error_set) == 1
 
     error = invalid.InvalidTeq(
         f"Invalid provided teq value ('potato'), accepted keyword is: '{utils.CLOSED_KEYWORD}'",
         'valve', 'closed', (2, 1, 'A2'), wrong_keyword_teq)
 
+    assert error in pc.error_set
+
+
+def test_edge_id_error():
+    wrong_node = 5
+
+    states = {
+        'open': {
+            (wrong_node, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        },
+        'closed': {
+            (1, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        }
+    }
+    edges = [(1, 2, 'A1'), (2, 1, 'A2')]
+
+    pc = top.PlumbingComponent('valve', states, edges)
+
+    assert not pc.is_valid()
+    error = invalid.InvalidComponentEdge(
+        f"Edge '({wrong_node}, 2, 'A1')' not found in provided edge list.", (wrong_node, 2, 'A1'))
     assert error in pc.error_set
 
 
@@ -82,7 +105,7 @@ def test_multiple_errors():
     states, edges = two_edge_states_edges(normal_teq, normal_teq, teq_too_low, wrong_keyword_teq)
     pc = top.PlumbingComponent('valve', states, edges)
 
-    assert not pc.valid
+    assert not pc.is_valid()
     assert len(pc.error_set) == 2
 
     error1 = invalid.InvalidTeq(

--- a/topside/plumbing/tests/test_plumbing_component.py
+++ b/topside/plumbing/tests/test_plumbing_component.py
@@ -41,7 +41,7 @@ def test_plumbing_component_setup():
         }
     }
     assert pc1.is_valid()
-    assert not pc1.error_set
+    assert not pc1.list_errors()
 
 
 def test_minimum_teq():
@@ -51,12 +51,12 @@ def test_minimum_teq():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.error_set) == 1
+    assert len(pc.list_errors()) == 1
 
     error = invalid.InvalidTeq(
         f'Provided teq value too low, minimum value is: {utils.micros_to_s(utils.TEQ_MIN)}s',
         'valve', 'closed', (2, 1, 'A2'), teq_too_low)
-    assert error in pc.error_set
+    assert error in pc.list_errors()
 
 
 def test_invalid_keyword():
@@ -66,13 +66,13 @@ def test_invalid_keyword():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.error_set) == 1
+    assert len(pc.list_errors()) == 1
 
     error = invalid.InvalidTeq(
         f"Invalid provided teq value ('potato'), accepted keyword is: '{utils.CLOSED_KEYWORD}'",
         'valve', 'closed', (2, 1, 'A2'), wrong_keyword_teq)
 
-    assert error in pc.error_set
+    assert error in pc.list_errors()
 
 
 def test_duplicate_edges():
@@ -94,7 +94,7 @@ def test_duplicate_edges():
     assert not pc.is_valid()
 
     error = invalid.InvalidComponentEdge(f"Duplicate edges '{edge}' found in edge list.", edge)
-    assert error in pc.error_set
+    assert error in pc.list_errors()
 
 
 def test_edge_id_error():
@@ -117,7 +117,7 @@ def test_edge_id_error():
     assert not pc.is_valid()
     error = invalid.InvalidComponentEdge(
         f"Edge '({wrong_node}, 2, 'A1')' not found in provided edge list.", (wrong_node, 2, 'A1'))
-    assert error in pc.error_set
+    assert error in pc.list_errors()
 
 
 def test_multiple_errors():
@@ -128,7 +128,7 @@ def test_multiple_errors():
     pc = top.PlumbingComponent('valve', states, edges)
 
     assert not pc.is_valid()
-    assert len(pc.error_set) == 2
+    assert len(pc.list_errors()) == 2
 
     error1 = invalid.InvalidTeq(
         f"Provided teq value too low, minimum value is: {utils.micros_to_s(utils.TEQ_MIN)}s",
@@ -139,8 +139,8 @@ def test_multiple_errors():
         f" accepted keyword is: '{utils.CLOSED_KEYWORD}'",
         'valve', 'closed', (2, 1, 'A2'), wrong_keyword_teq)
 
-    assert error1 in pc.error_set
-    assert error2 in pc.error_set
+    assert error1 in pc.list_errors()
+    assert error2 in pc.list_errors()
 
 
 def test_component_dicts_remain_unchanged():

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -123,6 +123,38 @@ def test_new_component_state():
     assert plumb.current_state('valve2') == 'open'
 
 
+def test_invalid_component():
+    wrong_node = 5
+    pc_states = {
+        'open': {
+            (1, wrong_node, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        },
+        'closed': {
+            (1, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        }
+    }
+    pc_edges = [(1, 2, 'A1'), (2, 1, 'A2')]
+    invalid_pc = top.PlumbingComponent('valve', pc_states, pc_edges)
+
+    assert not invalid_pc.is_valid()
+
+    plumb = top.PlumbingEngine()
+
+    with pytest.raises(exceptions.BadInputError) as err:
+        plumb.load_graph({'valve': invalid_pc}, {1: 1, 2: 2}, {1: 100}, {'valve': 'open'})
+    assert str(err.value) == "Node 1 not found in graph."
+
+    assert not plumb.is_valid()
+    assert len(plumb.error_set) == 1
+
+    error = invalid.InvalidComponentName(
+        "Component with name 'valve' is not valid;"
+        " component cannot be loaded in until errors are resolved.", 'valve')
+    assert error in plumb.error_set
+
+
 def test_missing_component():
     wrong_component_name = 'potato'
     pc1 = test_utils.create_component(0, 0, 0, 0, 'valve1', 'A')

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -11,8 +11,8 @@ def test_empty_graph():
     plumb = top.PlumbingEngine()
 
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert not plumb.list_edges()
-    assert not plumb.list_nodes()
+    assert not plumb.edges()
+    assert not plumb.nodes()
 
 
 def test_open_closed_valves():
@@ -21,13 +21,13 @@ def test_open_closed_valves():
         0, 0, utils.CLOSED_KEYWORD, utils.CLOSED_KEYWORD)
 
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': 0}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.FC_MAX}),
         (3, 2, 'valve2.B2', {'FC': utils.FC_MAX})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -41,13 +41,13 @@ def test_arbitrary_states():
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -66,13 +66,13 @@ def test_load_graph_to_empty():
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -93,13 +93,13 @@ def test_replace_graph():
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -113,7 +113,7 @@ def test_new_component_state():
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)
     plumb.set_component_state('valve1', 'open')
 
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
@@ -147,12 +147,12 @@ def test_invalid_component():
     assert str(err.value) == "Node 1 not found in graph."
 
     assert not plumb.is_valid()
-    assert len(plumb.list_errors()) == 1
+    assert len(plumb.errors()) == 1
 
     error = invalid.InvalidComponentName(
         "Component with name 'valve' is not valid;"
         " component cannot be loaded in until errors are resolved.", 'valve')
-    assert error in plumb.list_errors()
+    assert error in plumb.errors()
 
 
 def test_missing_component():
@@ -177,7 +177,7 @@ def test_missing_component():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.list_errors()) == 2
+    assert len(plumb.errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -187,8 +187,8 @@ def test_missing_component():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.list_errors()
-    assert error2 in plumb.list_errors()
+    assert error1 in plumb.errors()
+    assert error2 in plumb.errors()
 
 
 def test_wrong_node_mapping():
@@ -222,7 +222,7 @@ def test_wrong_node_mapping():
     # since the component node stored in the component's states dict needs to be
     # translated into a main graph node. So 4 errors total, but they're identical
     # so we should get one original error and one multi-error note.
-    assert len(plumb.list_errors()) == 2
+    assert len(plumb.errors()) == 2
 
     error = invalid.InvalidComponentNode(
         f"Component 'valve1', node {proper_node_name} not found in mapping dict.",
@@ -231,8 +231,8 @@ def test_wrong_node_mapping():
     duplicate_error = invalid.DuplicateError(invalid.multi_error_msg(
         f"Component 'valve1', node {proper_node_name} not found in mapping dict."), error)
 
-    assert error in plumb.list_errors()
-    assert duplicate_error in plumb.list_errors()
+    assert error in plumb.errors()
+    assert duplicate_error in plumb.errors()
 
 
 def test_missing_node_pressure():
@@ -282,13 +282,13 @@ def test_missing_initial_state():
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.list_errors()) == 1
+    assert len(plumb.errors()) == 1
 
     error = invalid.InvalidComponentName(
         f"Component '{proper_component_name}' state not found in initial states dict.",
         proper_component_name)
 
-    assert error in plumb.list_errors()
+    assert error in plumb.errors()
 
 
 def test_error_reset():
@@ -409,7 +409,7 @@ def test_load_errorless_graph():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.list_errors()) == 2
+    assert len(plumb.errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -419,8 +419,8 @@ def test_load_errorless_graph():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.list_errors()
-    assert error2 in plumb.list_errors()
+    assert error1 in plumb.errors()
+    assert error2 in plumb.errors()
 
     plumb0 = test_utils.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -11,8 +11,8 @@ def test_empty_graph():
     plumb = top.PlumbingEngine()
 
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert not list(plumb.plumbing_graph.edges(data=True, keys=True))
-    assert not list(plumb.plumbing_graph.nodes(data=True))
+    assert not plumb.list_edges()
+    assert not plumb.list_nodes()
 
 
 def test_open_closed_valves():
@@ -21,13 +21,13 @@ def test_open_closed_valves():
         0, 0, utils.CLOSED_KEYWORD, utils.CLOSED_KEYWORD)
 
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': 0}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.FC_MAX}),
         (3, 2, 'valve2.B2', {'FC': utils.FC_MAX})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -41,13 +41,13 @@ def test_arbitrary_states():
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -66,13 +66,13 @@ def test_load_graph_to_empty():
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -93,13 +93,13 @@ def test_replace_graph():
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -113,7 +113,7 @@ def test_new_component_state():
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)
     plumb.set_component_state('valve1', 'open')
 
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
@@ -147,12 +147,12 @@ def test_invalid_component():
     assert str(err.value) == "Node 1 not found in graph."
 
     assert not plumb.is_valid()
-    assert len(plumb.error_set) == 1
+    assert len(plumb.list_errors()) == 1
 
     error = invalid.InvalidComponentName(
         "Component with name 'valve' is not valid;"
         " component cannot be loaded in until errors are resolved.", 'valve')
-    assert error in plumb.error_set
+    assert error in plumb.list_errors()
 
 
 def test_missing_component():
@@ -177,7 +177,7 @@ def test_missing_component():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.error_set) == 2
+    assert len(plumb.list_errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -187,8 +187,8 @@ def test_missing_component():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.error_set
-    assert error2 in plumb.error_set
+    assert error1 in plumb.list_errors()
+    assert error2 in plumb.list_errors()
 
 
 def test_wrong_node_mapping():
@@ -222,7 +222,7 @@ def test_wrong_node_mapping():
     # since the component node stored in the component's states dict needs to be
     # translated into a main graph node. So 4 errors total, but they're identical
     # so we should get one original error and one multi-error note.
-    assert len(plumb.error_set) == 2
+    assert len(plumb.list_errors()) == 2
 
     error = invalid.InvalidComponentNode(
         f"Component 'valve1', node {proper_node_name} not found in mapping dict.",
@@ -231,8 +231,8 @@ def test_wrong_node_mapping():
     duplicate_error = invalid.DuplicateError(invalid.multi_error_msg(
         f"Component 'valve1', node {proper_node_name} not found in mapping dict."), error)
 
-    assert error in plumb.error_set
-    assert duplicate_error in plumb.error_set
+    assert error in plumb.list_errors()
+    assert duplicate_error in plumb.list_errors()
 
 
 def test_missing_node_pressure():
@@ -282,13 +282,13 @@ def test_missing_initial_state():
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.error_set) == 1
+    assert len(plumb.list_errors()) == 1
 
     error = invalid.InvalidComponentName(
         f"Component '{proper_component_name}' state not found in initial states dict.",
         proper_component_name)
 
-    assert error in plumb.error_set
+    assert error in plumb.list_errors()
 
 
 def test_error_reset():
@@ -409,7 +409,7 @@ def test_load_errorless_graph():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.error_set) == 2
+    assert len(plumb.list_errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -419,8 +419,8 @@ def test_load_errorless_graph():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.error_set
-    assert error2 in plumb.error_set
+    assert error1 in plumb.list_errors()
+    assert error2 in plumb.list_errors()
 
     plumb0 = test_utils.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -20,11 +20,11 @@ def test_add_to_empty():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(2))}),
         (2, 1, 'valve.A2', {'FC': 0})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 20}),
         (2, {'pressure': 0})
     ]
@@ -45,7 +45,7 @@ def test_add_component():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
@@ -53,7 +53,7 @@ def test_add_component():
         (3, 4, 'valve3.C1', {'FC': utils.teq_to_FC(0)}),
         (4, 3, 'valve3.C2', {'FC': utils.teq_to_FC(utils.s_to_micros(1))})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -115,11 +115,11 @@ def test_remove_component():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
     ]
@@ -149,13 +149,13 @@ def test_add_remove():
     assert plumb.is_valid()
     assert plumb.time_resolution ==\
         int(utils.s_to_micros(old_lowest_teq) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -197,13 +197,13 @@ def test_remove_add_errors():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -234,7 +234,7 @@ def test_remove_errors_wrong_component_name():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.error_set) == 2
+    assert len(plumb.list_errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -244,18 +244,18 @@ def test_remove_errors_wrong_component_name():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.error_set
-    assert error2 in plumb.error_set
+    assert error1 in plumb.list_errors()
+    assert error2 in plumb.list_errors()
 
     plumb.remove_component(wrong_component_name)
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0))}),
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
     ]
@@ -269,13 +269,13 @@ def test_reverse_orientation():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': 0}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -337,7 +337,7 @@ def test_set_pressure():
     plumb.set_pressure(1, 200)
     plumb.set_pressure(2, 7000)
 
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 200}),
         (2, {'pressure': 7000}),
         (3, {'pressure': 100}),
@@ -347,7 +347,7 @@ def test_set_pressure():
     plumb.set_pressure(4, 10)
     plumb.set_pressure(1, 0)
 
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 7000}),
         (3, {'pressure': 100}),
@@ -375,7 +375,7 @@ def test_set_pressure_errors():
         plumb.set_pressure(4, not_a_number)
     assert str(err.value) == f"Pressure {not_a_number} must be a number."
 
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -388,7 +388,7 @@ def test_set_pressure_errors():
     assert str(err.value) == f"Node {nonexistent_node} not found in graph."
 
     plumb.set_pressure(4, 100)
-    assert list(plumb.plumbing_graph.nodes(data=True)) == [
+    assert plumb.list_nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -417,7 +417,7 @@ def test_set_teq():
 
     assert plumb.time_resolution ==\
         int(utils.s_to_micros(new_lowest_teq) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert list(plumb.plumbing_graph.edges(data=True, keys=True)) == [
+    assert plumb.list_edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(7))}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(new_lowest_teq))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -20,11 +20,11 @@ def test_add_to_empty():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == utils.DEFAULT_TIME_RESOLUTION_MICROS
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(2))}),
         (2, 1, 'valve.A2', {'FC': 0})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 20}),
         (2, {'pressure': 0})
     ]
@@ -45,7 +45,7 @@ def test_add_component():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
@@ -53,7 +53,7 @@ def test_add_component():
         (3, 4, 'valve3.C1', {'FC': utils.teq_to_FC(0)}),
         (4, 3, 'valve3.C2', {'FC': utils.teq_to_FC(utils.s_to_micros(1))})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -115,11 +115,11 @@ def test_remove_component():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
     ]
@@ -149,13 +149,13 @@ def test_add_remove():
     assert plumb.is_valid()
     assert plumb.time_resolution ==\
         int(utils.s_to_micros(old_lowest_teq) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -197,13 +197,13 @@ def test_remove_add_errors():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -234,7 +234,7 @@ def test_remove_errors_wrong_component_name():
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
     assert not plumb.is_valid()
-    assert len(plumb.list_errors()) == 2
+    assert len(plumb.errors()) == 2
 
     error1 = invalid.InvalidComponentName(
         f"Component with name '{wrong_component_name}' not found in mapping dict.",
@@ -244,18 +244,18 @@ def test_remove_errors_wrong_component_name():
         f"Component '{wrong_component_name}' state not found in initial states dict.",
         wrong_component_name)
 
-    assert error1 in plumb.list_errors()
-    assert error2 in plumb.list_errors()
+    assert error1 in plumb.errors()
+    assert error2 in plumb.errors()
 
     plumb.remove_component(wrong_component_name)
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0))}),
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
     ]
@@ -269,13 +269,13 @@ def test_reverse_orientation():
 
     assert plumb.is_valid()
     assert plumb.time_resolution == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': 0}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100})
@@ -337,7 +337,7 @@ def test_set_pressure():
     plumb.set_pressure(1, 200)
     plumb.set_pressure(2, 7000)
 
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 200}),
         (2, {'pressure': 7000}),
         (3, {'pressure': 100}),
@@ -347,7 +347,7 @@ def test_set_pressure():
     plumb.set_pressure(4, 10)
     plumb.set_pressure(1, 0)
 
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 7000}),
         (3, {'pressure': 100}),
@@ -375,7 +375,7 @@ def test_set_pressure_errors():
         plumb.set_pressure(4, not_a_number)
     assert str(err.value) == f"Pressure {not_a_number} must be a number."
 
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -388,7 +388,7 @@ def test_set_pressure_errors():
     assert str(err.value) == f"Node {nonexistent_node} not found in graph."
 
     plumb.set_pressure(4, 100)
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 100}),
@@ -417,7 +417,7 @@ def test_set_teq():
 
     assert plumb.time_resolution ==\
         int(utils.s_to_micros(new_lowest_teq) / utils.DEFAULT_RESOLUTION_SCALE)
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(7))}),
         (2, 1, 'valve1.A2', {'FC': utils.teq_to_FC(utils.s_to_micros(new_lowest_teq))}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -83,6 +83,31 @@ def test_add_component_errors():
         f"Component '{name}', node {right_node} not found in mapping dict."
 
 
+def test_add_invalid_component():
+    plumb = test_utils.two_valve_setup(
+        0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)
+
+    wrong_node = 5
+    pc_states = {
+        'open': {
+            (1, wrong_node, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        },
+        'closed': {
+            (1, 2, 'A1'): 0,
+            (2, 1, 'A2'): 0
+        }
+    }
+    pc_edges = [(1, 2, 'A1'), (2, 1, 'A2')]
+    invalid_pc = top.PlumbingComponent('valve', pc_states, pc_edges)
+
+    assert not invalid_pc.is_valid()
+
+    with pytest.raises(exceptions.BadInputError) as err:
+        plumb.add_component(invalid_pc, {1: 3, 2: 4}, 'open')
+    assert str(err.value) == "Component not valid; all errors must be resolved before loading in."
+
+
 def test_remove_component():
     plumb = test_utils.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED_KEYWORD, 0.5, 0.2, 10, utils.CLOSED_KEYWORD)

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -74,8 +74,8 @@ def test_current_pressures():
         2: 50
     }
 
-    list_nodes = [1, 2]
-    assert plumb.current_pressures(list_nodes) == {
+    nodes = [1, 2]
+    assert plumb.current_pressures(nodes) == {
         1: 100,
         2: 50
     }
@@ -198,14 +198,14 @@ def test_list_functions():
     plumb = top.PlumbingEngine(
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
 
-    assert plumb.list_edges() == [
+    assert plumb.edges() == [
         (1, 2, 'valve1.A1', {'FC': utils.teq_to_FC(utils.s_to_micros(10))}),
         (2, 1, 'valve1.A2', {'FC': 0}),
         (2, 3, 'valve2.B1', {'FC': utils.teq_to_FC(utils.s_to_micros(0.5))}),
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
 
-    assert plumb.list_edges(data=False) == [
+    assert plumb.edges(data=False) == [
         (1, 2, 'valve1.A1'),
         (2, 1, 'valve1.A2'),
         (2, 3, 'valve2.B1'),
@@ -213,14 +213,14 @@ def test_list_functions():
     ]
 
     # Pressure at node 3 will be 0, since the provided one was invalid
-    assert plumb.list_nodes() == [
+    assert plumb.nodes() == [
         (1, {'pressure': 0}),
         (2, {'pressure': 0}),
         (3, {'pressure': 0})
     ]
 
-    assert plumb.list_nodes(data=False) == [1, 2, 3]
+    assert plumb.nodes(data=False) == [1, 2, 3]
 
-    assert plumb.list_errors() == {
+    assert plumb.errors() == {
         invalid.InvalidNodePressure(f"Negative pressure {negative_pressure} not allowed.", 3)
     }


### PR DESCRIPTION
Added more error catches for components, and added a check in the Plumbing Engine to prevent loading in invalid components. 
Also applied the PlumbingEngine code fixes we've made in the past while to PlumbingComponent, like changing `is_valid()` and querying functions.
While I was at it I also added some super basic querying functions and updated the unit tests to use those rather than Networkx functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/15)
<!-- Reviewable:end -->
