### PR TITLE
Optimize the optimizer

### DIFF
--- a/topside/visualization/layout.py
+++ b/topside/visualization/layout.py
@@ -2,6 +2,28 @@ import networkx as nx
 
 
 def terminal_graph(plumbing_engine):
+    """
+    Create an augmented graph suitable for visualization.
+
+    The terminal graph T is created by the following process, for a
+    plumbing engine P with graph G:
+        1. All non-atm nodes from G are placed in T.
+        2. For each component C in P:
+            a) For each node n in C:
+                i. Create a node C_n in T, where the node name of C_n is
+                   <name of C>.<name of n>.
+                ii. Create an edge in T from C_n to C.mapping[n].
+
+    Parameters
+    ----------
+
+    plumbing_engine: topside.PlumbingEngine
+
+    Returns
+    -------
+
+    t: networkx.Graph
+    """
     t = nx.Graph()
 
     for name, c in plumbing_engine.component_dict.items():

--- a/topside/visualization/layout.py
+++ b/topside/visualization/layout.py
@@ -7,12 +7,16 @@ def terminal_graph(plumbing_engine):
 
     The terminal graph T is created by the following process, for a
     plumbing engine P with graph G:
-        1. All non-atm nodes from G are placed in T.
+        1. For each non-atm node in G:
+            a) Create a node of the same name in T.
         2. For each component C in P:
             a) For each node n in C:
                 i. Create a node C_n in T, where the node name of C_n is
                    <name of C>.<name of n>.
-                ii. Create an edge in T from C_n to C.mapping[n].
+                ii. Find the node v in G to which n is mapped. This is
+                    defined as P.mapping[C][n].
+                iii. Create an edge in T from C_n to the node in T with
+                     the same name as v.
 
     Parameters
     ----------

--- a/topside/visualization/layout.py
+++ b/topside/visualization/layout.py
@@ -1,6 +1,3 @@
-from dataclasses import dataclass
-
-import numpy as np
 import networkx as nx
 
 

--- a/topside/visualization/optimization/cost_terms.py
+++ b/topside/visualization/optimization/cost_terms.py
@@ -1,55 +1,39 @@
 import numpy as np
 
 
-# TODO(jacob): Once vectorization is done, split this into two cost
-# terms for better readability.
 class NeighboringDistance():
-    def __init__(self, g, node_indices, node_component_neighbors, settings):
+    def __init__(self, g, node_indices, node_component_neighbors, settings, internal):
         self.num_nodes = len(node_indices)
 
-        self.internal_mask = np.ones((self.num_nodes, self.num_nodes))
-        self.neighbors_mask = np.ones((self.num_nodes, self.num_nodes))
+        self.mask = np.ones((self.num_nodes, self.num_nodes))
 
         for node in g:
             i = node_indices[node]
             for neighbor in g.neighbors(node):
                 j = node_indices[neighbor]
-                if neighbor in node_component_neighbors[node]:
-                    self.internal_mask[i, j] = 0
-                    self.internal_mask[j, i] = 0
-                else:
-                    self.neighbors_mask[i, j] = 0
-                    self.neighbors_mask[j, i] = 0
+                if internal is (neighbor in node_component_neighbors[node]):
+                    self.mask[i, j] = 0
+                    self.mask[j, i] = 0
 
-        self.internal_weight = settings.internal_weight
-        self.neighbors_weight = settings.neighbors_weight
-        self.nominal_dist_internal = settings.nominal_dist_internal
-        self.nominal_dist_neighbors = settings.nominal_dist_neighbors
+        if internal:
+            self.nominal_dist = settings.nominal_dist_internal
+            self.weight = settings.internal_weight
+        else:
+            self.nominal_dist = settings.nominal_dist_neighbors
+            self.weight = settings.neighbors_weight
 
     def evaluate(self, costargs):
         cost = 0
         grad = np.zeros(self.num_nodes * 2)
 
-        internal_norms = np.ma.masked_array(costargs['norms'], mask=self.internal_mask)
-        neighbors_norms = np.ma.masked_array(costargs['norms'], mask=self.neighbors_mask)
+        norms = np.ma.masked_array(costargs['norms'], mask=self.mask)
 
-        internal_matrix = self.internal_weight * \
-            (self.nominal_dist_internal - internal_norms) ** 2
-        cost += np.sum(internal_matrix.filled(0))
+        cost_matrix = self.weight * (self.nominal_dist - norms) ** 2
+        cost += np.sum(cost_matrix.filled(0))
 
-        neighbors_matrix = self.neighbors_weight * \
-            (self.nominal_dist_neighbors - neighbors_norms) ** 2
-        cost += np.sum(neighbors_matrix.filled(0))
-
-        internal_grad_common = self.internal_weight * \
-            (internal_norms - self.nominal_dist_internal) * (4 / internal_norms)
-        internal_grad_matrix = costargs['deltas'] * internal_grad_common[:, :, None]
-        grad += np.reshape(np.sum(internal_grad_matrix.filled(0), axis=1), grad.shape)
-
-        neighbors_grad_common = self.neighbors_weight * \
-            (neighbors_norms - self.nominal_dist_neighbors) * (4 / neighbors_norms)
-        neighbors_grad_matrix = costargs['deltas'] * neighbors_grad_common[:, :, None]
-        grad += np.reshape(np.sum(neighbors_grad_matrix.filled(0), axis=1), grad.shape)
+        grad_common = self.weight * (norms - self.nominal_dist) * (4 / norms)
+        grad_matrix = costargs['deltas'] * grad_common[:, :, None]
+        grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
         return (cost, grad)
 
@@ -58,35 +42,32 @@ class NonNeighboringDistance:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         self.num_nodes = len(node_indices)
 
-        self.nonneighbors_mask = np.identity(self.num_nodes)
+        self.mask = np.identity(self.num_nodes)
 
         for node in g:
             i = node_indices[node]
 
             for neighbor in g.neighbors(node):
                 j = node_indices[neighbor]
-                self.nonneighbors_mask[i, j] = 1
-                self.nonneighbors_mask[j, i] = 1
+                self.mask[i, j] = 1
+                self.mask[j, i] = 1
 
-        self.others_weight = settings.others_weight
-        self.minimum_dist_others = settings.minimum_dist_others
+        self.weight = settings.others_weight
+        self.minimum_dist = settings.minimum_dist_others
 
     def evaluate(self, costargs):
         cost = 0
         grad = np.zeros(self.num_nodes * 2)
 
-        nodes_to_ignore = (costargs['norms'] >= self.minimum_dist_others)
-        mask = np.logical_or(self.nonneighbors_mask, nodes_to_ignore)
+        nodes_to_ignore = (costargs['norms'] >= self.minimum_dist)
+        mask = np.logical_or(self.mask, nodes_to_ignore)
 
         masked_norms = np.ma.masked_array(costargs['norms'], mask=mask)
 
-        cost_matrix = self.others_weight * (self.minimum_dist_others - masked_norms) ** 2
+        cost_matrix = self.weight * (self.minimum_dist - masked_norms) ** 2
         cost += np.sum(cost_matrix.filled(0))
 
-        grad_mask = np.repeat(mask, 2, axis=np.newaxis)
-
-        grad_common_term = self.others_weight * \
-            (masked_norms - self.minimum_dist_others) * (4 / masked_norms)
+        grad_common_term = self.weight * (masked_norms - self.minimum_dist) * (4 / masked_norms)
         grad_matrix = costargs['deltas'] * grad_common_term[:, :, None]
 
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
@@ -113,16 +94,16 @@ class CentroidDeviation:
                     self.cost_mask[i, j] = 0
                     self.grad_mask[j, i] = 0
 
-        self.centroid_deviation_weight = settings.centroid_deviation_weight
+        self.weight = settings.centroid_deviation_weight
 
-        grad_coefficients_diag = self.centroid_deviation_weight * 2 * np.identity(self.num_nodes)
+        grad_coeffs_diag = self.weight * 2 * np.identity(self.num_nodes)
 
-        grad_coefficients_off_diag = self.centroid_deviation_weight * -2 * \
+        grad_coeffs_off_diag = self.weight * -2 * \
             np.ones((self.num_nodes, self.num_nodes, 2)) / self.num_neighbors
-        np.fill_diagonal(grad_coefficients_off_diag[:, :, 0], 0)
-        np.fill_diagonal(grad_coefficients_off_diag[:, :, 1], 0)
+        np.fill_diagonal(grad_coeffs_off_diag[:, :, 0], 0)
+        np.fill_diagonal(grad_coeffs_off_diag[:, :, 1], 0)
 
-        self.grad_coefficients = grad_coefficients_off_diag + grad_coefficients_diag[:, :, None]
+        self.grad_coeffs = grad_coeffs_off_diag + grad_coeffs_diag[:, :, None]
 
     def evaluate(self, costargs):
         cost = 0
@@ -131,7 +112,7 @@ class CentroidDeviation:
         masked_deltas = np.ma.masked_array(costargs['deltas'], mask=self.cost_mask)
         centroid_deviations = np.sum(masked_deltas, axis=1) / self.num_neighbors
 
-        cost_matrix = self.centroid_deviation_weight * centroid_deviations ** 2
+        cost_matrix = self.weight * centroid_deviations ** 2
         cost += np.sum(cost_matrix.filled(0))
 
         reshaped = np.reshape(centroid_deviations, (1, self.num_nodes, 2))
@@ -139,7 +120,7 @@ class CentroidDeviation:
 
         grad_deviations = np.ma.masked_array(repeated, mask=self.grad_mask)
 
-        grad_matrix = self.grad_coefficients * grad_deviations
+        grad_matrix = self.grad_coeffs * grad_deviations
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
         return (cost, grad)
@@ -149,28 +130,28 @@ class RightAngleDeviation:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         self.num_nodes = len(node_indices)
 
-        self.internal_mask = np.ones((self.num_nodes, self.num_nodes, 2))
+        self.mask = np.ones((self.num_nodes, self.num_nodes, 2))
         for node in g:
             i = node_indices[node]
             for neighbor in node_component_neighbors[node]:
                 j = node_indices[neighbor]
-                self.internal_mask[i, j] = 0
-                self.internal_mask[j, i] = 0
+                self.mask[i, j] = 0
+                self.mask[j, i] = 0
 
-        self.right_angle_weight = settings.right_angle_weight
+        self.weight = settings.right_angle_weight
 
     def evaluate(self, costargs):
         cost = 0
         grad = np.zeros(self.num_nodes * 2)
 
-        internal_deltas = np.ma.masked_array(costargs['deltas'], mask=self.internal_mask)
+        internal_deltas = np.ma.masked_array(costargs['deltas'], mask=self.mask)
 
         dxdy = np.product(internal_deltas, axis=2)
 
-        cost_matrix = self.right_angle_weight * dxdy ** 2
+        cost_matrix = self.weight * dxdy ** 2
         cost += np.sum(cost_matrix.filled(0))
 
-        grad_common = self.right_angle_weight * 4 * dxdy[:, :, None]
+        grad_common = self.weight * 4 * dxdy[:, :, None]
         grad_matrix = grad_common * np.flip(internal_deltas, axis=2)
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
@@ -181,15 +162,15 @@ class HorizontalDeviation:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         self.num_nodes = len(node_indices)
 
-        self.internal_mask = np.ones((self.num_nodes, self.num_nodes))
+        self.mask = np.ones((self.num_nodes, self.num_nodes))
         for node in g:
             i = node_indices[node]
             for neighbor in node_component_neighbors[node]:
                 j = node_indices[neighbor]
-                self.internal_mask[i, j] = 0
-                self.internal_mask[j, i] = 0
+                self.mask[i, j] = 0
+                self.mask[j, i] = 0
 
-        self.horizontal_weight = settings.horizontal_weight
+        self.weight = settings.horizontal_weight
 
     def evaluate(self, costargs):
         cost = 0
@@ -197,13 +178,13 @@ class HorizontalDeviation:
 
         delta_y = costargs['deltas'][:, :, 1]
 
-        internal_delta_y = np.ma.masked_array(delta_y, mask=self.internal_mask)
+        internal_delta_y = np.ma.masked_array(delta_y, mask=self.mask)
 
-        cost_matrix = self.horizontal_weight * internal_delta_y ** 2
+        cost_matrix = self.weight * internal_delta_y ** 2
         cost += np.sum(cost_matrix.filled(0))
 
         grad_matrix = np.ma.masked_array(np.zeros((self.num_nodes, self.num_nodes, 2)))
-        grad_matrix[:, :, 1] = self.horizontal_weight * 4 * internal_delta_y
+        grad_matrix[:, :, 1] = self.weight * 4 * internal_delta_y
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
         return (cost, grad)

--- a/topside/visualization/optimization/cost_terms.py
+++ b/topside/visualization/optimization/cost_terms.py
@@ -9,7 +9,7 @@ class NeighboringDistance():
 
         self.internal_mask = np.ones((self.num_nodes, self.num_nodes))
         self.neighbors_mask = np.ones((self.num_nodes, self.num_nodes))
-        
+
         for node in g:
             i = node_indices[node]
             for neighbor in g.neighbors(node):
@@ -59,7 +59,7 @@ class NonNeighboringDistance:
         self.num_nodes = len(node_indices)
 
         self.nonneighbors_mask = np.identity(self.num_nodes)
-        
+
         for node in g:
             i = node_indices[node]
 
@@ -67,7 +67,7 @@ class NonNeighboringDistance:
                 j = node_indices[neighbor]
                 self.nonneighbors_mask[i, j] = 1
                 self.nonneighbors_mask[j, i] = 1
-        
+
         self.others_weight = settings.others_weight
         self.minimum_dist_others = settings.minimum_dist_others
 
@@ -112,15 +112,16 @@ class CentroidDeviation:
                     j = node_indices[neighbor]
                     self.cost_mask[i, j] = 0
                     self.grad_mask[j, i] = 0
-        
+
         self.centroid_deviation_weight = settings.centroid_deviation_weight
-        
+
         grad_coefficients_diag = self.centroid_deviation_weight * 2 * np.identity(self.num_nodes)
-        
-        grad_coefficients_off_diag = self.centroid_deviation_weight * -2 * np.ones((self.num_nodes, self.num_nodes, 2)) / self.num_neighbors
+
+        grad_coefficients_off_diag = self.centroid_deviation_weight * -2 * \
+            np.ones((self.num_nodes, self.num_nodes, 2)) / self.num_neighbors
         np.fill_diagonal(grad_coefficients_off_diag[:, :, 0], 0)
         np.fill_diagonal(grad_coefficients_off_diag[:, :, 1], 0)
-        
+
         self.grad_coefficients = grad_coefficients_off_diag + grad_coefficients_diag[:, :, None]
 
     def evaluate(self, costargs):
@@ -179,7 +180,7 @@ class RightAngleDeviation:
 class HorizontalDeviation:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         self.num_nodes = len(node_indices)
-    
+
         self.internal_mask = np.ones((self.num_nodes, self.num_nodes))
         for node in g:
             i = node_indices[node]
@@ -187,7 +188,7 @@ class HorizontalDeviation:
                 j = node_indices[neighbor]
                 self.internal_mask[i, j] = 0
                 self.internal_mask[j, i] = 0
-        
+
         self.horizontal_weight = settings.horizontal_weight
 
     def evaluate(self, costargs):

--- a/topside/visualization/optimization/cost_terms.py
+++ b/topside/visualization/optimization/cost_terms.py
@@ -20,7 +20,7 @@ class NeighboringDistance():
 
         Parameters
         ----------
-        
+
         g: graph
             The graph for which this cost term will be evaluated.
             Typically, this is a NetworkX graph, but it can be any type
@@ -32,7 +32,7 @@ class NeighboringDistance():
         node_indices: dict
             Dict where node_indices[n] is the index i of node n in the
             cost vector.
-        
+
         node_component_neighbors: dict
             Dict where, for a given node n, node_component_neighbors[n]
             is a list of all nodes in g that are both neighbors of n
@@ -121,7 +121,7 @@ class NonNeighboringDistance:
 
         Parameters
         ----------
-        
+
         g: graph
             The graph for which this cost term will be evaluated.
             Typically, this is a NetworkX graph, but it can be any type
@@ -133,7 +133,7 @@ class NonNeighboringDistance:
         node_indices: dict
             Dict where node_indices[n] is the index i of node n in the
             cost vector.
-        
+
         node_component_neighbors: dict
             Dict where, for a given node n, node_component_neighbors[n]
             is a list of all nodes in g that are both neighbors of n
@@ -213,7 +213,7 @@ class CentroidDeviation:
 
         Parameters
         ----------
-        
+
         g: graph
             The graph for which this cost term will be evaluated.
             Typically, this is a NetworkX graph, but it can be any type
@@ -225,7 +225,7 @@ class CentroidDeviation:
         node_indices: dict
             Dict where node_indices[n] is the index i of node n in the
             cost vector.
-        
+
         node_component_neighbors: dict
             Dict where, for a given node n, node_component_neighbors[n]
             is a list of all nodes in g that are both neighbors of n
@@ -314,7 +314,7 @@ class RightAngleDeviation:
 
         Parameters
         ----------
-        
+
         g: graph
             The graph for which this cost term will be evaluated.
             Typically, this is a NetworkX graph, but it can be any type
@@ -326,7 +326,7 @@ class RightAngleDeviation:
         node_indices: dict
             Dict where node_indices[n] is the index i of node n in the
             cost vector.
-        
+
         node_component_neighbors: dict
             Dict where, for a given node n, node_component_neighbors[n]
             is a list of all nodes in g that are both neighbors of n
@@ -396,7 +396,7 @@ class HorizontalDeviation:
 
         Parameters
         ----------
-        
+
         g: graph
             The graph for which this cost term will be evaluated.
             Typically, this is a NetworkX graph, but it can be any type
@@ -408,7 +408,7 @@ class HorizontalDeviation:
         node_indices: dict
             Dict where node_indices[n] is the index i of node n in the
             cost vector.
-        
+
         node_component_neighbors: dict
             Dict where, for a given node n, node_component_neighbors[n]
             is a list of all nodes in g that are both neighbors of n

--- a/topside/visualization/optimization/cost_terms.py
+++ b/topside/visualization/optimization/cost_terms.py
@@ -1,195 +1,252 @@
 import numpy as np
 
 
-# TODO(jacob): Vectorize all of these for (hopefully) significant
-# speedup.
-
 # TODO(jacob): Once vectorization is done, split this into two cost
 # terms for better readability.
 def neighboring_distance_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    xr = np.reshape(x, (-1, 2))
+    cost = NeighboringDistance(g, node_indices, node_component_neighbors, settings)
+    return cost.evaluate(x)
 
-    cost = 0
-    grad = np.zeros(x.shape[0])
 
-    internal_mask = np.ones((xr.shape[0], xr.shape[0]))
-    neighbors_mask = np.ones((xr.shape[0], xr.shape[0]))
-    for node in g:
-        i = node_indices[node]
-        for neighbor in g.neighbors(node):
-            j = node_indices[neighbor]
-            if neighbor in node_component_neighbors[node]:
-                internal_mask[i, j] = 0
-                internal_mask[j, i] = 0
-            else:
-                neighbors_mask[i, j] = 0
-                neighbors_mask[j, i] = 0
+class NeighboringDistance():
+    def __init__(self, g, node_indices, node_component_neighbors, settings):
+        num_nodes = len(node_indices)
 
-    deltas = xr[:, None, :] - xr[None, :, :]
-    norms = np.linalg.norm(deltas, axis=2)
+        self.internal_mask = np.ones((num_nodes, num_nodes))
+        self.neighbors_mask = np.ones((num_nodes, num_nodes))
+        
+        for node in g:
+            i = node_indices[node]
+            for neighbor in g.neighbors(node):
+                j = node_indices[neighbor]
+                if neighbor in node_component_neighbors[node]:
+                    self.internal_mask[i, j] = 0
+                    self.internal_mask[j, i] = 0
+                else:
+                    self.neighbors_mask[i, j] = 0
+                    self.neighbors_mask[j, i] = 0
 
-    internal_norms = np.ma.masked_array(norms, mask=internal_mask)
-    neighbors_norms = np.ma.masked_array(norms, mask=neighbors_mask)
+        self.internal_weight = settings.internal_weight
+        self.neighbors_weight = settings.neighbors_weight
+        self.nominal_dist_internal = settings.nominal_dist_internal
+        self.nominal_dist_neighbors = settings.nominal_dist_neighbors
 
-    internal_matrix = settings.internal_weight * \
-        (settings.nominal_dist_internal - internal_norms) ** 2
-    cost += np.sum(internal_matrix.filled(0))
+    def evaluate(self, x):
+        xr = np.reshape(x, (-1, 2))
 
-    neighbors_matrix = settings.neighbors_weight * \
-        (settings.nominal_dist_neighbors - neighbors_norms) ** 2
-    cost += np.sum(neighbors_matrix.filled(0))
+        cost = 0
+        grad = np.zeros(x.shape[0])
 
-    internal_grad_mask = np.repeat(internal_mask, 2, axis=np.newaxis)
-    neighbors_grad_mask = np.repeat(neighbors_mask, 2, axis=np.newaxis)
+        deltas = xr[:, None, :] - xr[None, :, :]
+        norms = np.linalg.norm(deltas, axis=2)
 
-    internal_grad_common = settings.internal_weight * \
-        (internal_norms - settings.nominal_dist_internal) * (4 / internal_norms)
-    internal_grad_matrix = deltas * internal_grad_common[:, :, None]
-    grad += np.reshape(np.sum(internal_grad_matrix.filled(0), axis=1), grad.shape)
+        internal_norms = np.ma.masked_array(norms, mask=self.internal_mask)
+        neighbors_norms = np.ma.masked_array(norms, mask=self.neighbors_mask)
 
-    neighbors_grad_common = settings.neighbors_weight * \
-        (neighbors_norms - settings.nominal_dist_neighbors) * (4 / neighbors_norms)
-    neighbors_grad_matrix = deltas * neighbors_grad_common[:, :, None]
-    grad += np.reshape(np.sum(neighbors_grad_matrix.filled(0), axis=1), grad.shape)
+        internal_matrix = self.internal_weight * \
+            (self.nominal_dist_internal - internal_norms) ** 2
+        cost += np.sum(internal_matrix.filled(0))
 
-    return (cost, grad)
+        neighbors_matrix = self.neighbors_weight * \
+            (self.nominal_dist_neighbors - neighbors_norms) ** 2
+        cost += np.sum(neighbors_matrix.filled(0))
+
+        internal_grad_common = self.internal_weight * \
+            (internal_norms - self.nominal_dist_internal) * (4 / internal_norms)
+        internal_grad_matrix = deltas * internal_grad_common[:, :, None]
+        grad += np.reshape(np.sum(internal_grad_matrix.filled(0), axis=1), grad.shape)
+
+        neighbors_grad_common = self.neighbors_weight * \
+            (neighbors_norms - self.nominal_dist_neighbors) * (4 / neighbors_norms)
+        neighbors_grad_matrix = deltas * neighbors_grad_common[:, :, None]
+        grad += np.reshape(np.sum(neighbors_grad_matrix.filled(0), axis=1), grad.shape)
+
+        return (cost, grad)
 
 
 def nonneighboring_distance_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    xr = np.reshape(x, (-1, 2))
+    cost = NonNeighboringDistance(g, node_indices, node_component_neighbors, settings)
+    return cost.evaluate(x)
 
-    cost = 0
-    grad = np.zeros(x.shape[0])
 
-    nonneighbors_mask = np.identity(xr.shape[0])
-    for node in g:
-        i = node_indices[node]
+class NonNeighboringDistance:
+    def __init__(self, g, node_indices, node_component_neighbors, settings):
+        num_nodes = len(node_indices)
 
-        for neighbor in g.neighbors(node):
-            j = node_indices[neighbor]
-            nonneighbors_mask[i, j] = 1
-            nonneighbors_mask[j, i] = 1
+        self.nonneighbors_mask = np.identity(num_nodes)
+        
+        for node in g:
+            i = node_indices[node]
 
-    deltas = xr[:, None, :] - xr[None, :, :]
-    norms = np.linalg.norm(deltas, axis=2)
+            for neighbor in g.neighbors(node):
+                j = node_indices[neighbor]
+                self.nonneighbors_mask[i, j] = 1
+                self.nonneighbors_mask[j, i] = 1
+        
+        self.others_weight = settings.others_weight
+        self.minimum_dist_others = settings.minimum_dist_others
 
-    nodes_to_ignore = (norms >= settings.minimum_dist_others)
-    mask = np.logical_or(nonneighbors_mask, nodes_to_ignore)
+    def evaluate(self, x):
+        xr = np.reshape(x, (-1, 2))
 
-    masked_norms = np.ma.masked_array(norms, mask=mask)
+        cost = 0
+        grad = np.zeros(x.shape[0])
 
-    cost_matrix = settings.others_weight * (settings.minimum_dist_others - masked_norms) ** 2
-    cost += np.sum(cost_matrix.filled(0))
+        deltas = xr[:, None, :] - xr[None, :, :]
+        norms = np.linalg.norm(deltas, axis=2)
 
-    grad_mask = np.repeat(mask, 2, axis=np.newaxis)
+        nodes_to_ignore = (norms >= self.minimum_dist_others)
+        mask = np.logical_or(self.nonneighbors_mask, nodes_to_ignore)
 
-    grad_common_term = settings.others_weight * \
-        (masked_norms - settings.minimum_dist_others) * (4 / masked_norms)
-    grad_matrix = deltas * grad_common_term[:, :, None]
+        masked_norms = np.ma.masked_array(norms, mask=mask)
 
-    grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+        cost_matrix = self.others_weight * (self.minimum_dist_others - masked_norms) ** 2
+        cost += np.sum(cost_matrix.filled(0))
 
-    return (cost, grad)
+        grad_mask = np.repeat(mask, 2, axis=np.newaxis)
+
+        grad_common_term = self.others_weight * \
+            (masked_norms - self.minimum_dist_others) * (4 / masked_norms)
+        grad_matrix = deltas * grad_common_term[:, :, None]
+
+        grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+
+        return (cost, grad)
 
 
 def centroid_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    xr = np.reshape(x, (-1, 2))
+    cost = CentroidDeviation(g, node_indices, node_component_neighbors, settings)
+    return cost.evaluate(x)
 
-    cost = 0
-    grad = np.zeros(x.shape[0])
 
-    cost_mask = np.ones((xr.shape[0], xr.shape[0], 2))
-    grad_mask = np.ones((xr.shape[0], xr.shape[0], 2))
-    num_neighbors = np.ones((xr.shape[0], 1))
-    for node in g:
-        i = node_indices[node]
-        neighbors = list(g.neighbors(node))
-        if len(neighbors) > 1:
-            grad_mask[i, i] = 0
-            num_neighbors[i] = len(neighbors)
-            for neighbor in neighbors:
-                j = node_indices[neighbor]
-                cost_mask[i, j] = 0
-                grad_mask[j, i] = 0
+class CentroidDeviation:
+    def __init__(self, g, node_indices, node_component_neighbors, settings):
+        num_nodes = len(node_indices)
 
-    deltas = xr[:, None, :] - xr[None, :, :]
-    masked_deltas = np.ma.masked_array(deltas, mask=cost_mask)
-    centroid_deviations = np.sum(masked_deltas, axis=1) / num_neighbors
+        self.cost_mask = np.ones((num_nodes, num_nodes, 2))
+        self.grad_mask = np.ones((num_nodes, num_nodes, 2))
+        self.num_neighbors = np.ones((num_nodes, 1))
 
-    cost_matrix = settings.centroid_deviation_weight * centroid_deviations ** 2
-    cost += np.sum(cost_matrix.filled(0))
+        for node in g:
+            i = node_indices[node]
+            neighbors = list(g.neighbors(node))
+            if len(neighbors) > 1:
+                self.grad_mask[i, i] = 0
+                self.num_neighbors[i] = len(neighbors)
+                for neighbor in neighbors:
+                    j = node_indices[neighbor]
+                    self.cost_mask[i, j] = 0
+                    self.grad_mask[j, i] = 0
+        
+        self.centroid_deviation_weight = settings.centroid_deviation_weight
+        
+        grad_coefficients_diag = self.centroid_deviation_weight * 2 * np.identity(num_nodes)
+        
+        grad_coefficients_off_diag = self.centroid_deviation_weight * -2 * np.ones((num_nodes, num_nodes, 2)) / self.num_neighbors
+        np.fill_diagonal(grad_coefficients_off_diag[:, :, 0], 0)
+        np.fill_diagonal(grad_coefficients_off_diag[:, :, 1], 0)
+        
+        self.grad_coefficients = grad_coefficients_off_diag + grad_coefficients_diag[:, :, None]
 
-    reshaped = np.reshape(centroid_deviations, (1, xr.shape[0], 2))
-    repeated = np.repeat(reshaped, xr.shape[0], axis=0)
+    def evaluate(self, x):
+        xr = np.reshape(x, (-1, 2))
 
-    grad_deviations = np.ma.masked_array(repeated, mask=grad_mask)
+        cost = 0
+        grad = np.zeros(x.shape[0])
 
-    grad_coefficients_diag = settings.centroid_deviation_weight * 2 * np.identity(xr.shape[0])
-    grad_coefficients_off_diag = settings.centroid_deviation_weight * -2 * np.ones((xr.shape[0], xr.shape[0], 2)) / num_neighbors
-    np.fill_diagonal(grad_coefficients_off_diag[:, :, 0], 0)
-    np.fill_diagonal(grad_coefficients_off_diag[:, :, 1], 0)
+        deltas = xr[:, None, :] - xr[None, :, :]
+        masked_deltas = np.ma.masked_array(deltas, mask=self.cost_mask)
+        centroid_deviations = np.sum(masked_deltas, axis=1) / self.num_neighbors
 
-    grad_coefficients = grad_coefficients_off_diag + grad_coefficients_diag[:, :, None]
+        cost_matrix = self.centroid_deviation_weight * centroid_deviations ** 2
+        cost += np.sum(cost_matrix.filled(0))
 
-    grad_matrix = grad_coefficients * grad_deviations
-    grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+        reshaped = np.reshape(centroid_deviations, (1, xr.shape[0], 2))
+        repeated = np.repeat(reshaped, xr.shape[0], axis=0)
 
-    return (cost, grad)
+        grad_deviations = np.ma.masked_array(repeated, mask=self.grad_mask)
+
+        grad_matrix = self.grad_coefficients * grad_deviations
+        grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+
+        return (cost, grad)
 
 
 def right_angle_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    xr = np.reshape(x, (-1, 2))
+    cost = RightAngleDeviation(g, node_indices, node_component_neighbors, settings)
+    return cost.evaluate(x)
 
-    cost = 0
-    grad = np.zeros(x.shape[0])
 
-    internal_mask = np.ones((xr.shape[0], xr.shape[0], 2))
-    for node in g:
-        i = node_indices[node]
-        for neighbor in node_component_neighbors[node]:
-            j = node_indices[neighbor]
-            internal_mask[i, j] = 0
-            internal_mask[j, i] = 0
+class RightAngleDeviation:
+    def __init__(self, g, node_indices, node_component_neighbors, settings):
+        num_nodes = len(node_indices)
 
-    deltas = xr[:, None, :] - xr[None, :, :]
+        self.internal_mask = np.ones((num_nodes, num_nodes, 2))
+        for node in g:
+            i = node_indices[node]
+            for neighbor in node_component_neighbors[node]:
+                j = node_indices[neighbor]
+                self.internal_mask[i, j] = 0
+                self.internal_mask[j, i] = 0
 
-    internal_deltas = np.ma.masked_array(deltas, mask=internal_mask)
+        self.right_angle_weight = settings.right_angle_weight
 
-    dxdy = np.product(internal_deltas, axis=2)
+    def evaluate(self, x):
+        xr = np.reshape(x, (-1, 2))
 
-    cost_matrix = settings.right_angle_weight * dxdy ** 2
-    cost += np.sum(cost_matrix.filled(0))
+        cost = 0
+        grad = np.zeros(x.shape[0])
 
-    grad_common = settings.right_angle_weight * 4 * dxdy[:, :, None]
-    grad_matrix = grad_common * np.flip(internal_deltas, axis=2)
-    grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+        deltas = xr[:, None, :] - xr[None, :, :]
 
-    return (cost, grad)
+        internal_deltas = np.ma.masked_array(deltas, mask=self.internal_mask)
+
+        dxdy = np.product(internal_deltas, axis=2)
+
+        cost_matrix = self.right_angle_weight * dxdy ** 2
+        cost += np.sum(cost_matrix.filled(0))
+
+        grad_common = self.right_angle_weight * 4 * dxdy[:, :, None]
+        grad_matrix = grad_common * np.flip(internal_deltas, axis=2)
+        grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+
+        return (cost, grad)
 
 
 def horizontal_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    xr = np.reshape(x, (-1, 2))
+    cost = HorizontalDeviation(g, node_indices, node_component_neighbors, settings)
+    return cost.evaluate(x)
 
-    cost = 0
-    grad = np.zeros(x.shape[0])
 
-    internal_mask = np.ones((xr.shape[0], xr.shape[0]))
-    for node in g:
-        i = node_indices[node]
-        for neighbor in node_component_neighbors[node]:
-            j = node_indices[neighbor]
-            internal_mask[i, j] = 0
-            internal_mask[j, i] = 0
+class HorizontalDeviation:
+    def __init__(self, g, node_indices, node_component_neighbors, settings):
+        num_nodes = len(node_indices)
+    
+        self.internal_mask = np.ones((num_nodes, num_nodes))
+        for node in g:
+            i = node_indices[node]
+            for neighbor in node_component_neighbors[node]:
+                j = node_indices[neighbor]
+                self.internal_mask[i, j] = 0
+                self.internal_mask[j, i] = 0
+        
+        self.horizontal_weight = settings.horizontal_weight
 
-    delta_y = (xr[:, None, :] - xr[None, :, :])[:, :, 1]
+    def evaluate(self, x):
+        xr = np.reshape(x, (-1, 2))
 
-    internal_delta_y = np.ma.masked_array(delta_y, mask=internal_mask)
+        cost = 0
+        grad = np.zeros(x.shape[0])
 
-    cost_matrix = settings.horizontal_weight * internal_delta_y ** 2
-    cost += np.sum(cost_matrix.filled(0))
+        delta_y = (xr[:, None, :] - xr[None, :, :])[:, :, 1]
 
-    grad_matrix = np.ma.masked_array(np.zeros((xr.shape[0], xr.shape[0], 2)))
-    grad_matrix[:, :, 1] = settings.horizontal_weight * 4 * internal_delta_y
-    grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+        internal_delta_y = np.ma.masked_array(delta_y, mask=self.internal_mask)
 
-    return (cost, grad)
+        cost_matrix = self.horizontal_weight * internal_delta_y ** 2
+        cost += np.sum(cost_matrix.filled(0))
+
+        grad_matrix = np.ma.masked_array(np.zeros((xr.shape[0], xr.shape[0], 2)))
+        grad_matrix[:, :, 1] = self.horizontal_weight * 4 * internal_delta_y
+        grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
+
+        return (cost, grad)

--- a/topside/visualization/optimization/cost_terms.py
+++ b/topside/visualization/optimization/cost_terms.py
@@ -3,11 +3,6 @@ import numpy as np
 
 # TODO(jacob): Once vectorization is done, split this into two cost
 # terms for better readability.
-def neighboring_distance_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    cost = NeighboringDistance(g, node_indices, node_component_neighbors, settings)
-    return cost.evaluate(x)
-
-
 class NeighboringDistance():
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         num_nodes = len(node_indices)
@@ -64,11 +59,6 @@ class NeighboringDistance():
         return (cost, grad)
 
 
-def nonneighboring_distance_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    cost = NonNeighboringDistance(g, node_indices, node_component_neighbors, settings)
-    return cost.evaluate(x)
-
-
 class NonNeighboringDistance:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         num_nodes = len(node_indices)
@@ -112,11 +102,6 @@ class NonNeighboringDistance:
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
         return (cost, grad)
-
-
-def centroid_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    cost = CentroidDeviation(g, node_indices, node_component_neighbors, settings)
-    return cost.evaluate(x)
 
 
 class CentroidDeviation:
@@ -172,11 +157,6 @@ class CentroidDeviation:
         return (cost, grad)
 
 
-def right_angle_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    cost = RightAngleDeviation(g, node_indices, node_component_neighbors, settings)
-    return cost.evaluate(x)
-
-
 class RightAngleDeviation:
     def __init__(self, g, node_indices, node_component_neighbors, settings):
         num_nodes = len(node_indices)
@@ -211,11 +191,6 @@ class RightAngleDeviation:
         grad += np.reshape(np.sum(grad_matrix.filled(0), axis=1), grad.shape)
 
         return (cost, grad)
-
-
-def horizontal_deviation_cost_term(x, g, node_indices, node_component_neighbors, settings):
-    cost = HorizontalDeviation(g, node_indices, node_component_neighbors, settings)
-    return cost.evaluate(x)
 
 
 class HorizontalDeviation:

--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -112,6 +112,22 @@ def make_initial_pos(num_nodes):
 
 
 def layout_plumbing_engine(plumbing_engine):
+    """
+    Given a plumbing engine, determine the best placement of components.
+
+    Parameters
+    ----------
+
+    plumbing_engine: topside.PlumbingEngine
+
+    Returns
+    -------
+
+    pos: dict
+        dict with keys corresponding to the nodes in the terminal graph
+        of plumbing_engine and values corresponding to the x-y point
+        that the node should be placed at.
+    """
     t = top.terminal_graph(plumbing_engine)
     components = top.component_nodes(plumbing_engine)
 

--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -36,7 +36,7 @@ def make_cost_terms(g, node_indices, node_component_neighbors, settings):
 
 def make_constraints(components, node_indices):
     # TODO(jacob): Reformulate this to only create one constraint that
-    # covers every component instead# of having N constraints for N
+    # covers every component instead of having N constraints for N
     # components.
     constraints = []
     for cnodes in components:
@@ -50,7 +50,7 @@ def make_constraints(components, node_indices):
         cons = NonlinearConstraint(cons_f, 0, 0, jac=cons_j, hess=cons_h)
 
         constraints.append(cons)
-    
+
     return constraints
 
 
@@ -58,10 +58,8 @@ def make_costargs(x):
     xr = np.reshape(x, (-1, 2))
     deltas = xr[:, None, :] - xr[None, :, :]
     norms = np.linalg.norm(deltas, axis=2)
-    
+
     costargs = {
-        'x': x,
-        'xr': xr,
         'deltas': deltas,
         'norms': norms
     }
@@ -126,7 +124,8 @@ def layout_plumbing_engine(plumbing_engine):
     initial_pos = make_initial_pos(t.order())
 
     stage_1_settings = OptimizerSettings(horizontal_weight=0.1)
-    stage_1_cost_terms = make_cost_terms(t, node_indices, node_component_neighbors, stage_1_settings)
+    stage_1_cost_terms = make_cost_terms(
+        t, node_indices, node_component_neighbors, stage_1_settings)
     stage_1_args = (stage_1_cost_terms)
 
     # TODO(jacob): Investigate if BFGS is really the best option.
@@ -137,7 +136,8 @@ def layout_plumbing_engine(plumbing_engine):
     constraints = make_constraints(components, node_indices)
 
     stage_2_settings = OptimizerSettings()
-    stage_2_cost_terms = make_cost_terms(t, node_indices, node_component_neighbors, stage_2_settings)
+    stage_2_cost_terms = make_cost_terms(
+        t, node_indices, node_component_neighbors, stage_2_settings)
     stage_2_args = (stage_2_cost_terms)
 
     fine_tuning_res = minimize(cost_fn, initial_positioning_res.x, jac=True, method='SLSQP',

--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -24,20 +24,21 @@ class OptimizerSettings:
     centroid_deviation_weight: float = 15
 
 
-def make_cost_terms(g, node_indices, node_component_neighbors, settings):
-    c1 = top.NeighboringDistance(g, node_indices, node_component_neighbors, settings)
-    c2 = top.NonNeighboringDistance(g, node_indices, node_component_neighbors, settings)
-    c3 = top.CentroidDeviation(g, node_indices, node_component_neighbors, settings)
-    c4 = top.RightAngleDeviation(g, node_indices, node_component_neighbors, settings)
-    c5 = top.HorizontalDeviation(g, node_indices, node_component_neighbors, settings)
+def make_cost_terms(g, node_indices, neighbors, settings):
+    c1 = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=True)
+    c2 = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=False)
+    c3 = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    c4 = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    c5 = top.RightAngleDeviation(g, node_indices, neighbors, settings)
+    c6 = top.HorizontalDeviation(g, node_indices, neighbors, settings)
 
-    return [c1, c2, c3, c4, c5]
+    return [c1, c2, c3, c4, c5, c6]
 
 
 def make_constraints(components, node_indices):
-    # TODO(jacob): Reformulate this to only create one constraint that
-    # covers every component instead of having N constraints for N
-    # components.
+    # TODO(jacob): Consider reformulating this to only create one
+    # constraint that covers every component instead of having N
+    # constraints for N components.
     constraints = []
     for cnodes in components:
         i = node_indices[cnodes[0]]
@@ -116,19 +117,21 @@ def layout_plumbing_engine(plumbing_engine):
 
     node_indices = {n: i for i, n in enumerate(t.nodes)}
 
-    node_component_neighbors = {n: [] for n in t.nodes}
+    neighbors = {n: [] for n in t.nodes}
     for cnodes in components:
         for n in cnodes:
-            node_component_neighbors[n] = [v for v in t.neighbors(n) if v in cnodes]
+            neighbors[n] = [v for v in t.neighbors(n) if v in cnodes]
 
     initial_pos = make_initial_pos(t.order())
 
     stage_1_settings = OptimizerSettings(horizontal_weight=0.1)
     stage_1_cost_terms = make_cost_terms(
-        t, node_indices, node_component_neighbors, stage_1_settings)
+        t, node_indices, neighbors, stage_1_settings)
     stage_1_args = (stage_1_cost_terms)
 
     # TODO(jacob): Investigate if BFGS is really the best option.
+    # Consider implementing the Hessian of the cost function in order
+    # to try other methods (trust-exact, trust-krylov, etc.).
     initial_positioning_res = minimize(cost_fn, initial_pos, jac=True, method='BFGS',
                                        args=stage_1_args, options={'maxiter': 400})
     print(initial_positioning_res)
@@ -137,7 +140,7 @@ def layout_plumbing_engine(plumbing_engine):
 
     stage_2_settings = OptimizerSettings()
     stage_2_cost_terms = make_cost_terms(
-        t, node_indices, node_component_neighbors, stage_2_settings)
+        t, node_indices, neighbors, stage_2_settings)
     stage_2_args = (stage_2_cost_terms)
 
     fine_tuning_res = minimize(cost_fn, initial_positioning_res.x, jac=True, method='SLSQP',

--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -54,12 +54,31 @@ def make_constraints(components, node_indices):
     return constraints
 
 
+def make_costargs(x):
+    xr = np.reshape(x, (-1, 2))
+    deltas = xr[:, None, :] - xr[None, :, :]
+    norms = np.linalg.norm(deltas, axis=2)
+    
+    costargs = {
+        'x': x,
+        'xr': xr,
+        'deltas': deltas,
+        'norms': norms
+    }
+
+    return costargs
+
+
 def cost_fn(x, cost_terms):
+    # Pre-calculate deltas and norms to avoid repeated calculation
+    # between cost terms.
+    costargs = make_costargs(x)
+
     costs = []
     grads = []
 
     for ct in cost_terms:
-        cost, grad = ct.evaluate(x)
+        cost, grad = ct.evaluate(costargs)
         costs.append(cost)
         grads.append(grad)
 

--- a/topside/visualization/optimization/tests/test_cost_terms.py
+++ b/topside/visualization/optimization/tests/test_cost_terms.py
@@ -4,7 +4,7 @@ import numpy as np
 import topside as top
 
 
-def make_engine_data():
+def make_one_component_engine_data():
     g = nx.Graph([(1, 'c1.1'), ('c1.1', 'c1.2'), ('c1.2', 2)])
     node_indices = {1: 0, 'c1.1': 1, 'c1.2': 2, 2: 3}
     neighbors = {1: [], 'c1.1': ['c1.2'], 'c1.2': ['c1.1'], 2: []}
@@ -12,8 +12,18 @@ def make_engine_data():
     return g, node_indices, neighbors
 
 
+def make_two_component_engine_data():
+    g = nx.Graph([(1, 'c1.1'), (1, 'c2.1'), ('c1.1', 'c1.2'),
+                  ('c2.1', 'c2.2'), ('c1.2', 2), ('c2.2', 2)])
+    node_indices = {1: 0, 'c1.1': 1, 'c2.1': 2, 'c1.2': 3, 'c2.2': 4,  2: 5}
+    neighbors = {'c1.1': ['c1.2'], 'c1.2': ['c1.1'],
+                 'c2.1': ['c2.2'], 'c2.2': ['c2.1'], 1: [], 2: []}
+
+    return g, node_indices, neighbors
+
+
 def test_neighboring_distance_cost_internal_zero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(neighbors_weight=0,
                                      nominal_dist_internal=7,
                                      internal_weight=1)
@@ -35,7 +45,7 @@ def test_neighboring_distance_cost_internal_zero():
 
 
 def test_neighboring_distance_cost_internal_nonzero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(neighbors_weight=0,
                                      nominal_dist_internal=7,
                                      internal_weight=1)
@@ -64,7 +74,7 @@ def test_neighboring_distance_cost_internal_nonzero():
 
 
 def test_neighboring_distance_cost_external_zero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(nominal_dist_neighbors=10,
                                      neighbors_weight=1,
                                      internal_weight=0)
@@ -86,7 +96,7 @@ def test_neighboring_distance_cost_external_zero():
 
 
 def test_neighboring_distance_cost_external_nonzero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(nominal_dist_neighbors=10,
                                      neighbors_weight=1,
                                      internal_weight=0)
@@ -115,7 +125,7 @@ def test_neighboring_distance_cost_external_nonzero():
 
 
 def test_nonneighboring_distance_cost_close():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(minimum_dist_others=10,
                                      others_weight=1)
 
@@ -142,8 +152,29 @@ def test_nonneighboring_distance_cost_close():
     np.testing.assert_equal(expected_grad, grad)
 
 
+def test_nonneighboring_distance_cost_right_at_boundary():
+    g, node_indices, neighbors = make_one_component_engine_data()
+    settings = top.OptimizerSettings(minimum_dist_others=10,
+                                     others_weight=1)
+
+    x = np.array([
+        [0, 0],
+        [0, 100],
+        [100, 100],
+        [0, 10]
+    ]).reshape((-1, 1))
+
+    expected_cost = 0
+    expected_grad = np.zeros(8)
+
+    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+
+    assert cost == expected_cost
+    np.testing.assert_equal(expected_grad, grad)
+
+
 def test_nonneighboring_distance_cost_far():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(minimum_dist_others=10,
                                      others_weight=1)
 
@@ -163,8 +194,72 @@ def test_nonneighboring_distance_cost_far():
     np.testing.assert_equal(expected_grad, grad)
 
 
+def test_nonneighboring_distance_cost_multiple_nodes_far():
+    g, node_indices, neighbors = make_two_component_engine_data()
+    settings = top.OptimizerSettings(minimum_dist_others=10,
+                                     others_weight=1)
+
+    x = np.array([
+        [0, 0],
+        [10, 0],
+        [10, 100],
+        [20, 0],
+        [20, 100],
+        [30, 0]
+    ]).reshape((-1, 1))
+
+    expected_cost = 0
+    expected_grad = np.zeros(12)
+
+    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+
+    assert cost == expected_cost
+    np.testing.assert_equal(expected_grad, grad)
+
+
+def test_nonneighboring_distance_cost_multiple_nodes_close():
+    g, node_indices, neighbors = make_two_component_engine_data()
+    settings = top.OptimizerSettings(minimum_dist_others=20,
+                                     others_weight=1)
+
+    x = np.array([
+        [0, 0],    # 1
+        [100, 0],  # c1.1
+        [103, 4],  # c2.1
+        [106, 1],  # c1.2
+        [109, 5],  # c2.2
+        [200, 0]   # 2
+    ]).reshape((-1, 1))
+
+    cost_11_21 = 2 * (20 - 5) ** 2
+    cost_11_22 = 2 * (20 - np.sqrt(106)) ** 2
+    cost_12_21 = 2 * (20 - np.sqrt(18)) ** 2
+    cost_12_22 = 2 * (20 - 5) ** 2
+    expected_cost = cost_11_21 + cost_11_22 + cost_12_21 + cost_12_22
+
+    # 2 nodes * (-2 * (D - norm) / norm) per node
+    common_11_21 = 2 * -2 * (20 - 5) / 5
+    common_11_22 = 2 * -2 * (20 - np.sqrt(106)) / np.sqrt(106)
+    common_12_21 = 2 * -2 * (20 - np.sqrt(18)) / np.sqrt(18)
+    common_12_22 = 2 * -2 * (20 - 5) / 5
+
+    expected_grad = np.array([
+        [0, 0],
+        [common_11_21 * -3 + common_11_22 * -9, common_11_21 * -4 + common_11_22 * -5],
+        [common_11_21 * 3 + common_12_21 * -3, common_11_21 * 4 + common_12_21 * 3],
+        [common_12_21 * 3 + common_12_22 * -3, common_12_21 * -3 + common_12_22 * -4],
+        [common_11_22 * 9 + common_12_22 * 3, common_11_22 * 5 + common_12_22 * 4],
+        [0, 0]
+    ]).flatten()
+
+    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+
+    assert cost == expected_cost
+    np.testing.assert_equal(expected_grad, grad)
+
+
 def test_centroid_deviation_cost_term_zero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -184,7 +279,7 @@ def test_centroid_deviation_cost_term_zero():
 
 
 def test_centroid_deviation_cost_term_nonzero_end_node_x():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -210,7 +305,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_x():
 
 
 def test_centroid_deviation_cost_term_nonzero_end_node_y():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -236,7 +331,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_y():
 
 
 def test_centroid_deviation_cost_term_nonzero_end_node_xy():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -263,7 +358,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_xy():
 
 
 def test_centroid_deviation_cost_term_nonzero_interior_node_x():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -290,7 +385,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_x():
 
 
 def test_centroid_deviation_cost_term_nonzero_interior_node_y():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -317,7 +412,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_y():
 
 
 def test_centroid_deviation_cost_term_nonzero_interior_node_xy():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(centroid_deviation_weight=1)
 
     x = np.array([
@@ -349,7 +444,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_xy():
 
 
 def test_right_angle_deviation_cost_zero_horizontal():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(right_angle_weight=1)
 
     x = np.array([
@@ -374,7 +469,7 @@ def test_right_angle_deviation_cost_zero_horizontal():
 
 
 def test_right_angle_deviation_cost_zero_vertical():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(right_angle_weight=1)
 
     x = np.array([
@@ -399,7 +494,7 @@ def test_right_angle_deviation_cost_zero_vertical():
 
 
 def test_right_angle_deviation_cost_nonzero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(right_angle_weight=1)
 
     x = np.array([
@@ -426,7 +521,7 @@ def test_right_angle_deviation_cost_nonzero():
 
 
 def test_horizontal_deviation_cost_zero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(horizontal_weight=1)
 
     x = np.array([
@@ -451,7 +546,7 @@ def test_horizontal_deviation_cost_zero():
 
 
 def test_horizontal_deviation_cost_nonzero():
-    g, node_indices, neighbors = make_engine_data()
+    g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(horizontal_weight=1)
 
     x = np.array([

--- a/topside/visualization/optimization/tests/test_cost_terms.py
+++ b/topside/visualization/optimization/tests/test_cost_terms.py
@@ -38,7 +38,8 @@ def test_neighboring_distance_cost_internal_zero():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    cost, grad = top.neighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -67,7 +68,8 @@ def test_neighboring_distance_cost_internal_nonzero():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.neighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -89,7 +91,8 @@ def test_neighboring_distance_cost_external_zero():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    cost, grad = top.neighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -118,7 +121,8 @@ def test_neighboring_distance_cost_external_nonzero():
         [common * 3, common * 4]
     ]).flatten()
 
-    cost, grad = top.neighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -146,7 +150,8 @@ def test_nonneighboring_distance_cost_close():
         [common * 3, common * 4]
     ]).flatten()
 
-    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -167,7 +172,8 @@ def test_nonneighboring_distance_cost_right_at_boundary():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -188,7 +194,8 @@ def test_nonneighboring_distance_cost_far():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -211,7 +218,8 @@ def test_nonneighboring_distance_cost_multiple_nodes_far():
     expected_cost = 0
     expected_grad = np.zeros(12)
 
-    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -252,7 +260,8 @@ def test_nonneighboring_distance_cost_multiple_nodes_close():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.nonneighboring_distance_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -272,7 +281,8 @@ def test_centroid_deviation_cost_term_zero():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -298,7 +308,8 @@ def test_centroid_deviation_cost_term_nonzero_end_node_x():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -324,7 +335,8 @@ def test_centroid_deviation_cost_term_nonzero_end_node_y():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -351,7 +363,8 @@ def test_centroid_deviation_cost_term_nonzero_end_node_xy():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -378,7 +391,8 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_x():
         [-common_2, 0]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -405,7 +419,8 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_y():
         [0, -common_2]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -437,7 +452,8 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_xy():
         [-common_x_2, -common_y_2]
     ]).flatten()
 
-    cost, grad = top.centroid_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -462,7 +478,8 @@ def test_right_angle_deviation_cost_zero_horizontal():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.right_angle_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -487,7 +504,8 @@ def test_right_angle_deviation_cost_zero_vertical():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.right_angle_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -514,7 +532,8 @@ def test_right_angle_deviation_cost_nonzero():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.right_angle_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)

--- a/topside/visualization/optimization/tests/test_cost_terms.py
+++ b/topside/visualization/optimization/tests/test_cost_terms.py
@@ -39,7 +39,7 @@ def test_neighboring_distance_cost_internal_zero():
     expected_grad = np.zeros(8)
 
     ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -69,7 +69,7 @@ def test_neighboring_distance_cost_internal_nonzero():
     ]).flatten()
 
     ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -92,7 +92,7 @@ def test_neighboring_distance_cost_external_zero():
     expected_grad = np.zeros(8)
 
     ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -122,7 +122,7 @@ def test_neighboring_distance_cost_external_nonzero():
     ]).flatten()
 
     ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -151,7 +151,7 @@ def test_nonneighboring_distance_cost_close():
     ]).flatten()
 
     ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -173,7 +173,7 @@ def test_nonneighboring_distance_cost_right_at_boundary():
     expected_grad = np.zeros(8)
 
     ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -195,7 +195,7 @@ def test_nonneighboring_distance_cost_far():
     expected_grad = np.zeros(8)
 
     ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -219,7 +219,7 @@ def test_nonneighboring_distance_cost_multiple_nodes_far():
     expected_grad = np.zeros(12)
 
     ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -261,7 +261,7 @@ def test_nonneighboring_distance_cost_multiple_nodes_close():
     ]).flatten()
 
     ct = top.NonNeighboringDistance(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -282,7 +282,7 @@ def test_centroid_deviation_cost_term_zero():
     expected_grad = np.zeros(8)
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -309,7 +309,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_x():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -336,7 +336,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_y():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -364,7 +364,7 @@ def test_centroid_deviation_cost_term_nonzero_end_node_xy():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -392,7 +392,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_x():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -420,7 +420,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_y():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -453,7 +453,7 @@ def test_centroid_deviation_cost_term_nonzero_interior_node_xy():
     ]).flatten()
 
     ct = top.CentroidDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -479,7 +479,7 @@ def test_right_angle_deviation_cost_zero_horizontal():
     ]).flatten()
 
     ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -505,7 +505,7 @@ def test_right_angle_deviation_cost_zero_vertical():
     ]).flatten()
 
     ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -533,7 +533,7 @@ def test_right_angle_deviation_cost_nonzero():
     ]).flatten()
 
     ct = top.RightAngleDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -559,7 +559,7 @@ def test_horizontal_deviation_cost_zero():
     ]).flatten()
 
     ct = top.HorizontalDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -585,7 +585,7 @@ def test_horizontal_deviation_cost_nonzero():
     ]).flatten()
 
     ct = top.HorizontalDeviation(g, node_indices, neighbors, settings)
-    cost, grad = ct.evaluate(x)
+    cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)

--- a/topside/visualization/optimization/tests/test_cost_terms.py
+++ b/topside/visualization/optimization/tests/test_cost_terms.py
@@ -22,10 +22,9 @@ def make_two_component_engine_data():
     return g, node_indices, neighbors
 
 
-def test_neighboring_distance_cost_internal_zero():
+def test_internal_distance_cost_zero():
     g, node_indices, neighbors = make_one_component_engine_data()
-    settings = top.OptimizerSettings(neighbors_weight=0,
-                                     nominal_dist_internal=7,
+    settings = top.OptimizerSettings(nominal_dist_internal=7,
                                      internal_weight=1)
 
     x = np.array([
@@ -38,17 +37,16 @@ def test_neighboring_distance_cost_internal_zero():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=True)
     cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
 
 
-def test_neighboring_distance_cost_internal_nonzero():
+def test_internal_distance_cost_nonzero():
     g, node_indices, neighbors = make_one_component_engine_data()
-    settings = top.OptimizerSettings(neighbors_weight=0,
-                                     nominal_dist_internal=7,
+    settings = top.OptimizerSettings(nominal_dist_internal=7,
                                      internal_weight=1)
 
     x = np.array([
@@ -68,18 +66,17 @@ def test_neighboring_distance_cost_internal_nonzero():
         [0, 0]
     ]).flatten()
 
-    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=True)
     cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
 
 
-def test_neighboring_distance_cost_external_zero():
+def test_neighboring_distance_cost_zero():
     g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(nominal_dist_neighbors=10,
-                                     neighbors_weight=1,
-                                     internal_weight=0)
+                                     neighbors_weight=1)
 
     x = np.array([
         [0, 0],
@@ -91,18 +88,17 @@ def test_neighboring_distance_cost_external_zero():
     expected_cost = 0
     expected_grad = np.zeros(8)
 
-    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=False)
     cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
 
 
-def test_neighboring_distance_cost_external_nonzero():
+def test_neighboring_distance_cost_nonzero():
     g, node_indices, neighbors = make_one_component_engine_data()
     settings = top.OptimizerSettings(nominal_dist_neighbors=10,
-                                     neighbors_weight=1,
-                                     internal_weight=0)
+                                     neighbors_weight=1)
 
     x = np.array([
         [0, 0],
@@ -121,7 +117,7 @@ def test_neighboring_distance_cost_external_nonzero():
         [common * 3, common * 4]
     ]).flatten()
 
-    ct = top.NeighboringDistance(g, node_indices, neighbors, settings)
+    ct = top.NeighboringDistance(g, node_indices, neighbors, settings, internal=False)
     cost, grad = ct.evaluate(top.make_costargs(x))
 
     assert cost == expected_cost

--- a/topside/visualization/optimization/tests/test_cost_terms.py
+++ b/topside/visualization/optimization/tests/test_cost_terms.py
@@ -558,7 +558,8 @@ def test_horizontal_deviation_cost_zero():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.horizontal_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.HorizontalDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)
@@ -583,7 +584,8 @@ def test_horizontal_deviation_cost_nonzero():
         [0, 0]
     ]).flatten()
 
-    cost, grad = top.horizontal_deviation_cost_term(x, g, node_indices, neighbors, settings)
+    ct = top.HorizontalDeviation(g, node_indices, neighbors, settings)
+    cost, grad = ct.evaluate(x)
 
     assert cost == expected_cost
     np.testing.assert_equal(expected_grad, grad)

--- a/topside/visualization/optimization/tests/test_optimization_utils.py
+++ b/topside/visualization/optimization/tests/test_optimization_utils.py
@@ -25,3 +25,31 @@ def test_vector_to_pos_dict():
     for k, v in expected.items():
         assert k in calculated
         np.testing.assert_array_equal(v, calculated[k])
+
+
+def test_make_costargs():
+    x = np.array([
+        [0, 0],
+        [3, 4],
+        [13, 14],
+        [17, 17]
+    ]).reshape((-1, 1))
+
+    expected_deltas = np.array([
+        [[0, 0], [-3, -4], [-13, -14], [-17, -17]],
+        [[3, 4], [0, 0], [-10, -10], [-14, -13]],
+        [[13, 14], [10, 10], [0, 0], [-4, -3]],
+        [[17, 17], [14, 13], [4, 3], [0, 0]]
+    ])
+
+    expected_norms = np.array([
+        [0, 5, np.sqrt(13**2 + 14**2), np.sqrt(2 * 17**2)],
+        [5, 0, np.sqrt(200), np.sqrt(14**2 + 13**2)],
+        [np.sqrt(13**2 + 14**2), np.sqrt(200), 0, 5],
+        [np.sqrt(2 * 17**2), np.sqrt(14**2 + 13**2), 5, 0]
+    ])
+
+    costargs = top.make_costargs(x)
+
+    np.testing.assert_equal(expected_deltas, costargs['deltas'])
+    np.testing.assert_equal(expected_norms, costargs['norms'])


### PR DESCRIPTION
Vectorize the graph layout optimization routine. Remove nested for loops and redundant calculations between cost terms and across iterations.

Speeds up `layout_plumbing_engine` by ~4.8x.

Current master:
```
mean time: 4.4294932126998905 seconds
max time: 4.631882905960083 seconds
min time: 4.306760311126709 seconds
```

This PR:
```
mean time: 0.9118092298507691 seconds
max time: 0.9235303401947021 seconds
min time: 0.8985953330993652 seconds
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/17)
<!-- Reviewable:end -->
