### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -1,4 +1,4 @@
-name: Build executable with pyinstaller
+name: Build Executable [PyInstaller]
 
 on:
   push:

--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -1,0 +1,40 @@
+name: Build executable with pyinstaller
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Format code
+      run: |
+        ./tools/format.sh
+    - name: Test with pytest
+      run: |
+        pytest
+    - name: Build and run application
+      run: |
+        ./tools/build_pyinstaller.sh
+        ./dist/topside/topside.exe

--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -25,9 +25,12 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
+        # error codes shown by `--select` can be found
+        # here (F): https://flake8.pycqa.org/en/latest/user/error-codes.html
+        # and here (E): https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -28,13 +28,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Format code
-      run: |
-        ./tools/format.sh
     - name: Test with pytest
       run: |
         pytest
     - name: Build and run application
       run: |
-        ./tools/build_pyinstaller.sh
-        ./dist/topside/topside.exe
+        bash tools/build_pyinstaller.sh
+        ./dist/Topside/Topside.exe

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Topside: Technical Operations Procedures Simulator & Integrated Development Environment
 
+![](https://github.com/waterloo-rocketry/topside/workflows/Build%20Executable%20[PyInstaller]/badge.svg)
+
 Waterloo Rocketry's operations simulator is a tool for modelling and simulating rocket launch systems and procedures.
 
 #### Requirements

--- a/tools/build_cxfreeze.sh
+++ b/tools/build_cxfreeze.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!//usr/bin/env bash
 
 set -e
 

--- a/tools/build_cxfreeze.sh
+++ b/tools/build_cxfreeze.sh
@@ -1,4 +1,4 @@
-#!//usr/bin/env bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/build_pyinstaller.sh
+++ b/tools/build_pyinstaller.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 if ! type pyinstaller &> /dev/null
 then

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 if ! type autopep8 &> /dev/null
 then

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Added continuous integration through GitHub Actions. Right now, the CI checks Pytest unit tests and the PyInstaller build on a Windows machine. I'll add more fleshed out checks in a later PR but for now it should ensure that core functionality works.

Currently, the workflow does the following:
    - lints the code with flake8
    - runs unit tests with Pytest
    - builds and tries to launch the executable with PyInstaller, since
      cx_Freeze is still broken

Later checks to be added:
    - check that `format.sh` has been run
    - potentially a cx_Freeze build, depending on where we choose to go with that
    - MacOS/Linux builds, as well as testing with different versions of Python.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/20)
<!-- Reviewable:end -->
