### PR TITLE
Fix the format script to work on untracked files

### DIFF
--- a/tools/format.sh
+++ b/tools/format.sh
@@ -10,7 +10,7 @@ fi
 WORKSPACE_DIR=$(git rev-parse --show-toplevel)
 cd "$WORKSPACE_DIR"
 
-FILES=$(git diff --name-only master | grep '\.py$')
+FILES=$({ git ls-files -o --exclude-standard && git diff --name-only master; } | grep '\.py$')
 
 if [ ! -z "$FILES" ]
 then


### PR DESCRIPTION
git diff --name-only master doesn't include untracked files, so the
format script wasn't actually doing anything to them. Add another line
to include these files as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/24)
<!-- Reviewable:end -->
