### PR TITLE
procedures: Introduce Procedure class

### DIFF
--- a/topside/procedures/__init__.py
+++ b/topside/procedures/__init__.py
@@ -1,2 +1,3 @@
 from topside.procedures.conditions import *
 from topside.procedures.procedures_engine import *
+from topside.procedures.procedure import *

--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -1,5 +1,6 @@
 class Immediate:
     """Condition that is always satisfied."""
+
     def update(self, state):
         """Update the condition with the latest state; a no-op."""
         pass
@@ -13,7 +14,7 @@ class And:
     """
     Condition representing a logical AND of multiple other conditions.
     """
-    
+
     def __init__(self, conditions):
         """
         Initialize the condition.
@@ -97,6 +98,7 @@ class Or:
 
 class WaitUntil:
     """Condition that is satisfied once a certain time is reached."""
+
     def __init__(self, t):
         """
         Initialize the condition.
@@ -136,6 +138,7 @@ class WaitUntil:
 
 class Comparison:
     """Base class for conditions comparing a pressure to a reference."""
+
     def __init__(self, node, pressure, comp_fn=None):
         """
         Initialize the Comparison condition.
@@ -233,6 +236,7 @@ class Equal(Comparison):
 
 class Less(Comparison):
     """Condition that tests if a pressure is less than a reference."""
+
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using less-than."""
         return current_pressure < reference_pressure
@@ -240,6 +244,7 @@ class Less(Comparison):
 
 class Greater(Comparison):
     """Condition that tests if a pressure is greater than a reference."""
+
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using greater-than."""
         return current_pressure > reference_pressure
@@ -247,6 +252,7 @@ class Greater(Comparison):
 
 class LessEqual(Comparison):
     """Condition that tests if a pressure is less than or equal to a reference."""
+
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using less-than-or-equal."""
         return current_pressure <= reference_pressure
@@ -254,6 +260,7 @@ class LessEqual(Comparison):
 
 class GreaterEqual(Comparison):
     """Condition that tests if a pressure is greater than or equal to a reference."""
+
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using greater-than-or-equal."""
         return current_pressure >= reference_pressure

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+
+# TODO(jacob): Consider if any of the classes in this file could simply
+# be NamedTuples instead.
+
+@dataclass
+class Action:
+    """
+    A state change for a single component in the plumbing engine.
+
+    Members
+    =======
+
+    component: str
+        The identifier of the component whose state will be changed.
+        If part of a procedure that will be executed, this must refer to
+        a valid component in the managed PlumbingEngine.
+
+    state: str
+        The state that the component will be set to. If part of a
+        procedure that will be executed, this must refer to a valid
+        state of `component`.
+    """
+    component: str
+    state: str
+
+
+@dataclass
+class Transition:
+    """
+    A transition between two states in the procedure graph.
+
+    Members
+    =======
+
+    procedure: str
+        The identifier of the procedure that the next step belongs to.
+
+    step: str
+        The identifier for the next procedure step.
+    """
+    procedure: str
+    step: str
+
+
+@dataclass
+class ProcedureStep:
+    """
+    A discrete state in the procedure graph.
+
+    Members
+    =======
+
+    step_id: str
+        An identifier for this procedure step. Expected to be unique
+        within the same procedure.
+
+    action: topside.Action
+        The action that should be executed when this step is performed.
+
+    conditions: dict
+        A dict mapping topside.Condition objects to Transition objects.
+        Each entry in `conditions` represents a conditional transition
+        from this ProcedureStep to another step, potentially in a
+        different proceddure. This dict is expected to be ordered in
+        terms of condition priority; if multiple conditions are
+        satisfied, the first one will be selected.
+    """
+    step_id: str
+    action: Action
+    conditions: dict
+
+
+@dataclass
+class Procedure:
+    """
+    A discrete state in the procedure graph.
+
+    Members
+    =======
+
+    procedure_id: str
+        An identifier for this procedure. Expected to be unique within
+        a given procedure suite.
+
+    steps: dict
+        A dict mapping step identifier strings to ProcedureStep objects.
+        This dict is expected to be ordered from first step to last
+        step.
+    """
+    procedure_id: str
+    steps: dict


### PR DESCRIPTION
Previously, a "procedure" was a graph of ProcedureSteps with arbitrary
transitions in between them. This commit changes "procedure" to refer to
a single linear chain of ProcedureSteps, and introduces the term
"procedure suite" to refer to the whole graph. This lays the groundwork
for visualizing procedures in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/39)
<!-- Reviewable:end -->
