### PR TITLE
plumbing: Allow fixed pressures

### DIFF
--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -10,7 +10,7 @@ import topside.plumbing.plumbing_utils as utils
 class PlumbingEngine:
     """Engine that represents a plumbing system."""
 
-    def __init__(self, components=None, mapping=None, initial_nodes=None, initial_states=None):
+    def __init__(self, components=None, mapping=None, initial_pressures=None, initial_states=None):
         """
         Initialize the plumbing engine.
 
@@ -28,8 +28,8 @@ class PlumbingEngine:
             mapping is a dict of {component_name: {component_node: main_graph_node}}, which is
             used to specify connectivity between components on the main graph.
 
-        initial_nodes: dict
-            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+        initial_pressures: dict
+            initial_pressures is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
             is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
             have to be exhaustive; if a node isn't specified its pressure will be set to a default
             of 0.
@@ -45,8 +45,8 @@ class PlumbingEngine:
             components = {}
         if not mapping:
             mapping = {}
-        if not initial_nodes:
-            initial_nodes = {}
+        if not initial_pressures:
+            initial_pressures = {}
         if not initial_states:
             initial_states = {}
 
@@ -55,9 +55,9 @@ class PlumbingEngine:
         self.plumbing_graph = nx.MultiDiGraph()
         self.error_set = set()
         self.fixed_pressures = {}
-        self.load_graph(components, mapping, initial_nodes, initial_states)
+        self.load_graph(components, mapping, initial_pressures, initial_states)
 
-    def load_graph(self, components, mapping, initial_nodes, initial_states):
+    def load_graph(self, components, mapping, initial_pressures, initial_states):
         """
         Load in a graph to the PlumbingEngine.
 
@@ -72,8 +72,8 @@ class PlumbingEngine:
             mapping is a dict of {component_name: {component_node: main_graph_node}}, which is
             used to specify connectivity between components on the main graph.
 
-        initial_nodes: dict
-            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+        initial_pressures: dict
+            initial_pressures is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
             is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
             have to be exhaustive; if a node isn't specified its pressure will be set to a default
             of 0.
@@ -86,7 +86,7 @@ class PlumbingEngine:
         errors renders the engine invalid; invalid engines cannot be solved.
         """
 
-        initial_nodes = copy.deepcopy(initial_nodes)
+        initial_pressures = copy.deepcopy(initial_pressures)
         initial_states = copy.deepcopy(initial_states)
 
         self.component_dict = copy.deepcopy(components)
@@ -119,7 +119,7 @@ class PlumbingEngine:
 
             # Only pass in those pressures that are relevant to the current component
             node_pressures = {}
-            for node, pressure in initial_nodes.items():
+            for node, pressure in initial_pressures.items():
                 if node in self.mapping[name].values():
                     node_pressures[node] = pressure
 
@@ -129,7 +129,7 @@ class PlumbingEngine:
         # Raise this error (instead of writing to the error set) because there's no intuitive
         # point to remove afterwards. Won't interfere with any engine setup, since it's at the very
         # end of the function call
-        for node in initial_nodes.keys():
+        for node in initial_pressures.keys():
             if node not in self.plumbing_graph.nodes():
                 raise exceptions.BadInputError(f"Node {node} not found in graph.")
 
@@ -211,7 +211,7 @@ class PlumbingEngine:
             state_id is the component's initial state.
 
         pressures: dict
-            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+            pressures is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
             is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
             have to be exhaustive; if a node isn't specified its pressure will be set to a default
             of 0.

--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -29,8 +29,10 @@ class PlumbingEngine:
             used to specify connectivity between components on the main graph.
 
         initial_nodes: dict
-            initial_nodes is a dict of {main_graph_node: initial_pressure}. The dict doesn't have to
-            be exhaustive; if a node isn't specified its pressure will be set to a default of 0.
+            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+            is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
+            have to be exhaustive; if a node isn't specified its pressure will be set to a default
+            of 0.
 
         initial_states: dict
             initial_states is a dict of {component_name: state_name}. Every component must
@@ -52,6 +54,7 @@ class PlumbingEngine:
         self.time = 0
         self.plumbing_graph = nx.MultiDiGraph()
         self.error_set = set()
+        self.fixed_pressures = {}
         self.load_graph(components, mapping, initial_nodes, initial_states)
 
     def load_graph(self, components, mapping, initial_nodes, initial_states):
@@ -70,8 +73,10 @@ class PlumbingEngine:
             used to specify connectivity between components on the main graph.
 
         initial_nodes: dict
-            initial_nodes is a dict of {main_graph_node: initial_pressure}. The dict doesn't have to
-            be exhaustive; if a node isn't specified its pressure will be set to a default of 0.
+            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+            is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
+            have to be exhaustive; if a node isn't specified its pressure will be set to a default
+            of 0.
 
         initial_states: dict
             initial_states is a dict of {component_name: state_name}. Every component must
@@ -81,12 +86,14 @@ class PlumbingEngine:
         errors renders the engine invalid; invalid engines cannot be solved.
         """
 
-        self.component_dict = copy.deepcopy(components)
-        self.mapping = copy.deepcopy(mapping)
-        self.plumbing_graph.clear()
-        self.error_set.clear()
         initial_nodes = copy.deepcopy(initial_nodes)
         initial_states = copy.deepcopy(initial_states)
+
+        self.component_dict = copy.deepcopy(components)
+        self.mapping = copy.deepcopy(mapping)
+
+        self.plumbing_graph.clear()
+        self.error_set.clear()
 
         for name, component in self.component_dict.items():
             if not component.is_valid():
@@ -204,8 +211,10 @@ class PlumbingEngine:
             state_id is the component's initial state.
 
         pressures: dict
-            pressures is a dict of {main_graph_node: inital_pressure}. It need not be exhaustive;
-            nodes that aren't specified receive a default value of 0.
+            initial_nodes is a dict of {main_graph_node: (initial_pressure, fixed)} where fixed
+            is a bool indicating whether the pressure must remain fixed or not. The dict doesn't
+            have to be exhaustive; if a node isn't specified its pressure will be set to a default
+            of 0.
 
         fail_silently: bool
             fail_silently controls whether errors are raised or written to the error set.
@@ -262,7 +271,7 @@ class PlumbingEngine:
         pressures = copy.deepcopy(pressures)
         for node_name, node_pressure in pressures.items():
             try:
-                self.set_pressure(node_name, node_pressure)
+                self.set_pressure(node_name, node_pressure[0], fixed=node_pressure[1])
             except exceptions.BadInputError as err:
                 if fail_silently:
                     if err.args[0] == f"Node {node_name} not found in graph.":
@@ -350,7 +359,7 @@ class PlumbingEngine:
         self.plumbing_graph.edges[edge1]['FC'] = self.plumbing_graph.edges[edge2]['FC']
         self.plumbing_graph.edges[edge2]['FC'] = temp
 
-    def set_pressure(self, node_name, pressure):
+    def set_pressure(self, node_name, pressure, fixed=False):
         """Set pressure at given node."""
         if not isinstance(pressure, (int, float)):
             raise exceptions.BadInputError(f"Pressure {pressure} must be a number.")
@@ -362,6 +371,11 @@ class PlumbingEngine:
             raise exceptions.BadInputError(f"Pressure for atmosphere node ({utils.ATM}) must be 0.")
 
         self.plumbing_graph.nodes[node_name]['pressure'] = pressure
+        if fixed:
+            self.fixed_pressures[node_name] = pressure
+
+        if not fixed and node_name in self.fixed_pressures:
+            del self.fixed_pressures[node_name]
 
     def set_teq(self, component_name, which_edge):
         """Set teq at each edge in provided dict for one component.
@@ -539,7 +553,7 @@ class PlumbingEngine:
             if self.time + self.time_res > max_time:
                 time_res = max_time - self.time
             for node, data in self.nodes():
-                if node == utils.ATM:
+                if node in self.fixed_pressures or node == utils.ATM:
                     continue
                 dp = 0
                 pressure = data['pressure']

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -59,7 +59,7 @@ def test_arbitrary_states():
 def test_load_graph_to_empty():
     plumb0 = test.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED, 0.5, 0.2, 10, utils.CLOSED)
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
 
     plumb = top.PlumbingEngine()
@@ -88,7 +88,7 @@ def test_replace_graph():
         0, 0, utils.CLOSED, utils.CLOSED,
         0, 0, utils.CLOSED, utils.CLOSED)
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
@@ -171,7 +171,7 @@ def test_missing_component():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -208,7 +208,7 @@ def test_wrong_node_mapping():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -251,7 +251,7 @@ def test_missing_node_pressure():
         }
     }
 
-    pressures = {wrong_node_name: 100, 2: 100}
+    pressures = {wrong_node_name: (100, False), 2: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     with pytest.raises(exceptions.BadInputError) as err:
         plumb = top.PlumbingEngine(
@@ -276,7 +276,7 @@ def test_missing_initial_state():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {wrong_component_name: 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -307,7 +307,7 @@ def test_error_reset():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -366,7 +366,7 @@ def test_engine_dicts_remain_unchanged():
             2: 3
         }
     }
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     component_dict = {'valve1': pc1, 'valve2': pc2}
     plumb = top.PlumbingEngine(
@@ -382,7 +382,7 @@ def test_engine_dicts_remain_unchanged():
             2: 3
         }
     }
-    assert pressures == {3: 100}
+    assert pressures == {3: (100, False)}
     assert default_states == {'valve1': 'closed', 'valve2': 'open'}
     assert component_dict == {'valve1': pc1, 'valve2': pc2}
 
@@ -403,7 +403,7 @@ def test_load_errorless_graph():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -424,9 +424,14 @@ def test_load_errorless_graph():
 
     plumb0 = test.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED, 0.5, 0.2, 10, utils.CLOSED)
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
 
     plumb.load_graph(plumb0.component_dict, plumb0.mapping, pressures, default_states)
 
     assert plumb.is_valid()
+
+
+def test_fixed_state():
+    plumb = test.two_valve_setup_fixed(1, 1, 1, 1, 1, 1, 1, 1)
+    assert plumb.fixed_pressures == {3: 100}

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -16,7 +16,7 @@ def test_add_to_empty():
         2: 2
     }
 
-    plumb.add_component(pc, mapping, 'open', {1: 20})
+    plumb.add_component(pc, mapping, 'open', {1: (20, False)})
 
     assert plumb.is_valid()
     assert plumb.time_res == utils.DEFAULT_TIME_RESOLUTION_MICROS
@@ -41,7 +41,7 @@ def test_add_component():
         2: 4
     }
 
-    plumb.add_component(pc, mapping, 'closed', {4: 50})
+    plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
 
     assert plumb.is_valid()
     assert plumb.time_res == int(utils.s_to_micros(0.2) / utils.DEFAULT_RESOLUTION_SCALE)
@@ -78,7 +78,7 @@ def test_add_component_errors():
     }
 
     with pytest.raises(exceptions.BadInputError) as err:
-        plumb.add_component(pc, mapping, 'closed', {4: 50})
+        plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
     assert str(err.value) ==\
         f"Component '{name}', node {right_node} not found in mapping dict."
 
@@ -139,7 +139,7 @@ def test_add_remove():
         2: 4
     }
 
-    plumb.add_component(pc, mapping, 'closed', {4: 50})
+    plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
 
     assert plumb.time_res ==\
         int(utils.s_to_micros(new_lowest_teq) / utils.DEFAULT_RESOLUTION_SCALE)
@@ -189,7 +189,7 @@ def test_remove_add_errors():
     }
 
     with pytest.raises(exceptions.BadInputError) as err:
-        plumb.add_component(pc, mapping, 'closed', {4: 50})
+        plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
     assert str(err.value) ==\
         f"Component '{name}', node {right_node} not found in mapping dict."
 
@@ -228,7 +228,7 @@ def test_remove_errors_wrong_component_name():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -332,7 +332,7 @@ def test_set_pressure():
         1: 3,
         2: 4
     }
-    plumb.add_component(pc, mapping, 'closed', {4: 50})
+    plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
 
     plumb.set_pressure(1, 200)
     plumb.set_pressure(2, 7000)
@@ -363,7 +363,7 @@ def test_set_pressure_errors():
         1: 3,
         2: 4
     }
-    plumb.add_component(pc, mapping, 'closed', {4: 50})
+    plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
     pc_vent = test.create_component(0, 0, 0, 0, 'vent', 'D')
     mapping_vent = {
         1: 4,
@@ -535,3 +535,23 @@ def test_toggle_listing():
     assert 'valve1' in toggles
     assert 'valve2' in toggles
     assert 'tank' not in toggles
+
+
+def test_unfix_node():
+    plumb = test.two_valve_setup_fixed(1, 1, 1, 1, 1, 1, 1, 1)
+
+    assert plumb.fixed_pressures == {3: 100}
+
+    plumb.set_pressure(3, 100, False)
+
+    assert plumb.fixed_pressures == {}
+
+
+def test_fix_node():
+    plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
+
+    assert plumb.fixed_pressures == {}
+
+    plumb.set_pressure(3, 100, True)
+
+    assert plumb.fixed_pressures == {3: 100}

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -157,7 +157,7 @@ def test_FC_name_overlap():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'fill_valve': 'closed', 'remote_fill_valve': 'open'}
     plumb = top.PlumbingEngine(
         {'fill_valve': pc1, 'remote_fill_valve': pc2}, component_mapping, pressures, default_states)
@@ -193,7 +193,7 @@ def test_list_functions():
     }
 
     negative_pressure = -50
-    pressures = {3: negative_pressure}
+    pressures = {3: (negative_pressure, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)

--- a/topside/plumbing/tests/test_solving_algorithm.py
+++ b/topside/plumbing/tests/test_solving_algorithm.py
@@ -30,7 +30,7 @@ def test_invalid_engine():
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {wrong_component_name: pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
@@ -87,7 +87,40 @@ def test_misc_engine():
     step_state = step_plumb.step(steady_by)
     len_plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
     solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
-    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged, 
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
+                                  solve_state, step_state, solve_len, len_plumb.time_res)
+
+
+def test_set_fixed_pressure():
+    # steady_by needs to be a bit longer for this one since having the
+    # fixed pressure makes equalization take longer than the teq.
+    steady_by = utils.s_to_micros(3)
+    converged = {1: 100, 2: 100, 3: 100}
+
+    solve_plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
+    solve_plumb.set_pressure(3, 100, fixed=True)
+    solve_state = solve_plumb.solve()
+    step_plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
+    step_plumb.set_pressure(3, 100, fixed=True)
+    step_state = step_plumb.step(steady_by)
+    len_plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
+    len_plumb.set_pressure(3, 100, fixed=True)
+    solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
+                                  solve_state, step_state, solve_len, len_plumb.time_res)
+
+
+def test_create_fixed_pressure():
+    steady_by = utils.s_to_micros(3)
+    converged = {1: 100, 2: 100, 3: 100}
+
+    solve_plumb = test.two_valve_setup_fixed(1, 1, 1, 1, 1, 1, 1, 1)
+    solve_state = solve_plumb.solve()
+    step_plumb = test.two_valve_setup_fixed(1, 1, 1, 1, 1, 1, 1, 1)
+    step_state = step_plumb.step(steady_by)
+    len_plumb = test.two_valve_setup_fixed(1, 1, 1, 1, 1, 1, 1, 1)
+    solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
                                   solve_state, step_state, solve_len, len_plumb.time_res)
 
 
@@ -116,7 +149,7 @@ def test_1():
             2: utils.ATM
         }
     }
-    pressures = {1: 100}
+    pressures = {1: (100, False)}
     default_states = {'vent': 'open'}
 
     steady_by = utils.s_to_micros(1)
@@ -143,7 +176,7 @@ def test_2():
             2: 2
         }
     }
-    pressures = {1: 100}
+    pressures = {1: (100, False)}
     default_states = {'valve': 'open'}
     step_plumb = top.PlumbingEngine({'valve': pc}, mapping, pressures, default_states)
     step_plumb.set_component_state('valve', 'closed')
@@ -162,7 +195,7 @@ def test_2():
 
     len_plumb = top.PlumbingEngine({'valve': pc}, mapping, pressures, default_states)
     solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
-    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged, 
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
                                   solve_state, step_state, solve_len, len_plumb.time_res)
 
 
@@ -175,7 +208,7 @@ def test_3():
             2: utils.ATM
         }
     }
-    pressures = {1: 100}
+    pressures = {1: (100, False)}
     default_states = {'vent': 'closed'}
     plumb = top.PlumbingEngine({'vent': pc}, mapping, pressures, default_states)
     test.assert_no_change(plumb)
@@ -190,7 +223,7 @@ def test_4():
             2: 2
         }
     }
-    pressures = {1: 100}
+    pressures = {1: (100, False)}
     default_states = {'check': 'closed'}
     plumb = top.PlumbingEngine({'check': pc}, mapping, pressures, default_states)
     test.assert_no_change(plumb)
@@ -205,7 +238,7 @@ def test_5():
             2: 2
         }
     }
-    pressures = {1: 100}
+    pressures = {1: (100, False)}
     default_states = {'check': 'open'}
 
     steady_by = utils.s_to_micros(1)
@@ -219,7 +252,7 @@ def test_5():
 
     len_plumb = top.PlumbingEngine({'check': pc}, mapping, pressures, default_states)
     solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
-    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged, 
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
                                   solve_state, step_state, solve_len, len_plumb.time_res)
 
 
@@ -243,9 +276,9 @@ def test_6():
         }
     }
     pressures = {
-        1: 100,
-        2: 0,
-        3: 0
+        1: (100, False),
+        2: (0, False),
+        3: (0, False)
     }
 
     steady_by = utils.s_to_micros(1)
@@ -259,5 +292,5 @@ def test_6():
 
     len_plumb = top.PlumbingEngine({'three': pc}, mapping, pressures, {'three': 'open'})
     solve_len = len(len_plumb.solve(return_resolution=len_plumb.time_res))
-    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged, 
+    test.validate_plumbing_engine(step_plumb, solve_plumb, steady_by, converged,
                                   solve_state, step_state, solve_len, len_plumb.time_res)

--- a/topside/plumbing/tests/testing_utils.py
+++ b/topside/plumbing/tests/testing_utils.py
@@ -36,7 +36,30 @@ def two_valve_setup(vAs1_1, vAs1_2, vAs2_1, vAs2_2, vBs1_1, vBs1_2, vBs2_1, vBs2
         }
     }
 
-    pressures = {3: 100}
+    pressures = {3: (100, False)}
+    default_states = {'valve1': 'closed', 'valve2': 'open'}
+    plumb = top.PlumbingEngine(
+        {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)
+
+    return plumb
+
+
+def two_valve_setup_fixed(vAs1_1, vAs1_2, vAs2_1, vAs2_2, vBs1_1, vBs1_2, vBs2_1, vBs2_2):
+    pc1 = create_component(vAs1_1, vAs1_2, vAs2_1, vAs2_2, 'valve1', 'A')
+    pc2 = create_component(vBs1_1, vBs1_2, vBs2_1, vBs2_2, 'valve2', 'B')
+
+    component_mapping = {
+        'valve1': {
+            1: 1,
+            2: 2
+        },
+        'valve2': {
+            1: 2,
+            2: 3
+        }
+    }
+
+    pressures = {3: (100, True)}
     default_states = {'valve1': 'closed', 'valve2': 'open'}
     plumb = top.PlumbingEngine(
         {'valve1': pc1, 'valve2': pc2}, component_mapping, pressures, default_states)

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -31,7 +31,7 @@ def one_component_engine():
     c1 = top.PlumbingComponent('c1', states, edges)
 
     mapping = {'c1': {1: 1, 2: 2}}
-    pressures = {1: 0, 2: 0}
+    pressures = {1: (0, False), 2: (0, False)}
     initial_states = {'c1': 'closed'}
 
     return top.PlumbingEngine({'c1': c1}, mapping, pressures, initial_states)

--- a/topside/visualization/tests/test_layout.py
+++ b/topside/visualization/tests/test_layout.py
@@ -15,7 +15,7 @@ def one_component_engine():
     c1 = top.PlumbingComponent('c1', states, edges)
 
     mapping = {'c1': {1: 1, 2: 2}}
-    pressures = {1: 0, 2: 0}
+    pressures = {1: (0, False), 2: (0, False)}
     initial_states = {'c1': 'static'}
 
     return top.PlumbingEngine({'c1': c1}, mapping, pressures, initial_states)
@@ -34,7 +34,7 @@ def series_component_engine():
     c2 = top.PlumbingComponent('c2', states, edges)
 
     mapping = {'c1': {1: 1, 2: 2}, 'c2': {1: 2, 2: 3}}
-    pressures = {1: 0, 2: 0, 3: 0}
+    pressures = {1: (0, False), 2: (0, False), 3: (0, False)}
     initial_states = {'c1': 'static', 'c2': 'static'}
 
     return top.PlumbingEngine({'c1': c1, 'c2': c2}, mapping, pressures, initial_states)
@@ -53,7 +53,7 @@ def parallel_component_engine():
     c2 = top.PlumbingComponent('c2', states, edges)
 
     mapping = {'c1': {1: 1, 2: 2}, 'c2': {1: 1, 2: 2}}
-    pressures = {1: 0, 2: 0}
+    pressures = {1: (0, False), 2: (0, False)}
     initial_states = {'c1': 'static', 'c2': 'static'}
 
     return top.PlumbingEngine({'c1': c1, 'c2': c2}, mapping, pressures, initial_states)


### PR DESCRIPTION
Allows pressures to be fixed in the plumbing engine. I opted to modify how `initial_pressures` was specified instead of adding a whole new parameter since the information seemed to fit nicely that way, and added the `fixed_pressures` attribute to the engine itself. 

Unit tests are (obviously) included, and I also went through all our existing ones to modify how `initial_pressures` is formatted (which is why so many files are modified).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/40)
<!-- Reviewable:end -->
