### PR TITLE
viz: Fix layout demo initial pressures

### DIFF
--- a/topside/visualization/tests/layout_demo.py
+++ b/topside/visualization/tests/layout_demo.py
@@ -28,7 +28,7 @@ def make_engine():
     pressures = {}
     for k1, v1 in mapping.items():
         for k2, v2 in v1.items():
-            pressures[v2] = 0
+            pressures[v2] = (0, False)
 
     component_dict = {k: top.PlumbingComponent(k, states, edges) for k in mapping.keys()}
     initial_states = {k: 'static' for k in mapping.keys()}


### PR DESCRIPTION
layout_demo.py was still using the old PlumbingEngine interface, causing
it to TypeError on construction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/41)
<!-- Reviewable:end -->
