### PR TITLE
plumbing: add component accessor method

### DIFF
--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -502,13 +502,16 @@ class PlumbingEngine:
         return ret
 
     def errors(self):
-        return self.error_set
+        return copy.deepcopy(self.error_set)
 
     def nodes(self, data=True):
         return list(self.plumbing_graph.nodes(data=data))
 
     def edges(self, data=True):
         return list(self.plumbing_graph.edges(keys=True, data=data))
+
+    def components(self):
+        return copy.deepcopy(self.component_dict)
 
     def step(self, timestep=None):
         """ Return node pressures in the engine after timestep has elapsed.

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 import topside as top
@@ -224,3 +225,17 @@ def test_list_functions():
     assert plumb.errors() == {
         invalid.InvalidNodePressure(f"Negative pressure {negative_pressure} not allowed.", 3)
     }
+
+
+def test_components():
+    plumb = test.two_valve_setup(1, 1, 1, 1, 1, 1, 1, 1)
+    original_components = copy.deepcopy(plumb.component_dict)
+    queried_components = plumb.components()
+
+    assert list(original_components.keys()) == list(queried_components.keys())
+
+    queried_components.pop('valve1')
+
+    # make sure that changes to the returned dict aren't propagated through to the original
+    assert list(original_components.keys()) == list(plumb.component_dict.keys())
+    assert list(original_components.keys()) == list(plumb.components().keys())

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -1,4 +1,5 @@
 import copy
+
 import pytest
 
 import topside as top

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -236,6 +236,9 @@ def test_components():
 
     queried_components.pop('valve1')
 
+    assert len(queried_components) == 1
+    assert len(original_components) == 2
+
     # make sure that changes to the returned dict aren't propagated through to the original
     assert list(original_components.keys()) == list(plumb.component_dict.keys())
     assert list(original_components.keys()) == list(plumb.components().keys())


### PR DESCRIPTION
Adds an accessor method to the plumbing engine, which yields (a copy of) the dict of components stored in the plumbing engine. The copy is there to prevent changes to the returned dict from propagating through to the actual plumbing engine - I added a unit test for that. The same protection was added to the accessor that yields the error set. 

Artem should be able to use the method for his visualization stuff once this gets merged :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/48)
<!-- Reviewable:end -->
