### PR TITLE
procedures: Build procedure/suite dicts in __init__

### DIFF
--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -33,7 +33,7 @@ class And:
         Update all conditions with the latest state.
 
         Parameters
-        ==========
+        ----------
 
         state: dict
             state is expected to contain all information necessary for
@@ -76,7 +76,7 @@ class Or:
         Update all conditions with the latest state.
 
         Parameters
-        ==========
+        ----------
 
         state: dict
             state is expected to contain all information necessary for

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -1,16 +1,13 @@
 from dataclasses import dataclass
 
 
-# TODO(jacob): Consider if any of the classes in this file could simply
-# be NamedTuples instead.
-
 @dataclass
 class Action:
     """
     A state change for a single component in the plumbing engine.
 
     Members
-    =======
+    -------
 
     component: str
         The identifier of the component whose state will be changed.
@@ -32,7 +29,7 @@ class Transition:
     A transition between two states in the procedure graph.
 
     Members
-    =======
+    -------
 
     procedure: str
         The identifier of the procedure that the next step belongs to.
@@ -50,7 +47,7 @@ class ProcedureStep:
     A discrete state in the procedure graph.
 
     Members
-    =======
+    -------
 
     step_id: str
         An identifier for this procedure step. Expected to be unique
@@ -72,22 +69,23 @@ class ProcedureStep:
     conditions: dict
 
 
-@dataclass
 class Procedure:
-    """
-    A discrete state in the procedure graph.
+    """A sequence of discrete procedure steps."""
 
-    Members
-    =======
+    def __init__(self, procedure_id, steps):
+        """
+        Initialize the procedure.
 
-    procedure_id: str
-        An identifier for this procedure. Expected to be unique within
-        a given procedure suite.
+        Parameters
+        ----------
 
-    steps: dict
-        A dict mapping step identifier strings to ProcedureStep objects.
-        This dict is expected to be ordered from first step to last
-        step.
-    """
-    procedure_id: str
-    steps: dict
+        procedure_id: str
+            An identifier for this procedure. Expected to be unique
+            within a given procedure suite.
+
+        steps: list
+            A list of ProcedureStep objects ordered from first step to
+            last step.
+        """
+        self.procedure_id = procedure_id
+        self.steps = {step.step_id: step for step in steps}

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -83,9 +83,9 @@ class Procedure:
             An identifier for this procedure. Expected to be unique
             within a given procedure suite.
 
-        steps: list
-            A list of ProcedureStep objects ordered from first step to
-            last step.
+        steps: iterable
+            An iterable of ProcedureStep objects ordered from first step
+            to last step.
         """
         self.procedure_id = procedure_id
         self.steps = {step.step_id: step for step in steps}

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -16,14 +16,14 @@ class ProceduresEngine:
         Initialize the ProceduresEngine.
 
         Parameters
-        ==========
+        ----------
 
         plumbing_engine: topside.PlumbingEngine
             The PlumbingEngine that this ProceduresEngine should manage.
 
-        procedure_suite: dict
-            A procedure suite is represented as a dict mapping
-            procedure_id strings to Procedure objects.
+        procedure_suite: iterable
+            A procedure suite is any iterable of Procedure objects (but
+            typically a list).
 
         initial_step: str
             The initial procedure step that this ProceduresEngine should
@@ -34,13 +34,15 @@ class ProceduresEngine:
             actual "first step" of the procedure.
         """
         self._plumb = plumbing_engine
-        self._procedure_suite = suite
+        self._procedure_suite = None
         self.current_procedure_id = initial_procedure
+        self.current_step = None
+
+        if suite is not None:
+            self._procedure_suite = {proc.procedure_id: proc for proc in suite}
 
         if suite is not None and initial_procedure is not None and initial_step is not None:
             self.current_step = self._procedure_suite[initial_procedure].steps[initial_step]
-        else:
-            self.current_step = None
 
     def execute(self, action):
         """Execute an action on the managed PlumbingEngine."""
@@ -89,7 +91,7 @@ class ProceduresEngine:
         Step the managed plumbing engine in time and update conditions.
 
         Parameters
-        ==========
+        ----------
 
         timestep: int
             The number of microseconds that the managed plumbing engine

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -42,9 +42,9 @@ def single_procedure_suite():
     s2 = top.ProcedureStep('s2', open_action, {top.Immediate(): top.Transition('p1', 's3')})
     s3 = top.ProcedureStep('s3', close_action, {})
 
-    proc = top.Procedure('p1', {'s1': s1, 's2': s2, 's3': s3})
+    proc = top.Procedure('p1', [s1, s2, s3])
 
-    return {'p1': proc}
+    return [proc]
 
 
 def branching_procedure_suite_no_options():
@@ -56,10 +56,10 @@ def branching_procedure_suite_no_options():
     s2 = top.ProcedureStep('s2', halfway_open_action, {})
     s3 = top.ProcedureStep('s3', open_action, {})
 
-    proc_1 = top.Procedure('p1', {'s1': s1, 's2': s2, 's3': s3})
-    proc_2 = top.Procedure('p2', {'s1': s1, 's2': s2, 's3': s3})
+    proc_1 = top.Procedure('p1', [s1, s2, s3])
+    proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return {'p1': proc_1, 'p2': proc_2}
+    return [proc_1, proc_2]
 
 
 def branching_procedure_suite_one_option():
@@ -71,10 +71,10 @@ def branching_procedure_suite_one_option():
     s2 = top.ProcedureStep('s2', halfway_open_action, {})
     s3 = top.ProcedureStep('s3', open_action, {})
 
-    proc_1 = top.Procedure('p1', {'s1': s1, 's2': s2, 's3': s3})
-    proc_2 = top.Procedure('p2', {'s1': s1, 's2': s2, 's3': s3})
+    proc_1 = top.Procedure('p1', [s1, s2, s3])
+    proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return {'p1': proc_1, 'p2': proc_2}
+    return [proc_1, proc_2]
 
 
 def branching_procedure_suite_two_options():
@@ -86,10 +86,10 @@ def branching_procedure_suite_two_options():
     s2 = top.ProcedureStep('s2', halfway_open_action, {})
     s3 = top.ProcedureStep('s3', open_action, {})
 
-    proc_1 = top.Procedure('p1', {'s1': s1, 's2': s2, 's3': s3})
-    proc_2 = top.Procedure('p2', {'s1': s1, 's2': s2, 's3': s3})
+    proc_1 = top.Procedure('p1', [s1, s2, s3])
+    proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return {'p1': proc_1, 'p2': proc_2}
+    return [proc_1, proc_2]
 
 
 def test_execute_custom_action():
@@ -184,9 +184,9 @@ def test_transitions_respects_procedure_identifier():
     same_name_1 = top.ProcedureStep('same_name', action, {})
     same_name_2 = top.ProcedureStep('same_name', action, {})
 
-    proc_1 = top.Procedure('p1', {'s1': s1, 'same_name': same_name_1})
-    proc_2 = top.Procedure('p1', {'same_name': same_name_2})
-    proc_suite = {'p1': proc_1, 'p2': proc_2}
+    proc_1 = top.Procedure('p1', [s1, same_name_1])
+    proc_2 = top.Procedure('p2', [same_name_2])
+    proc_suite = [proc_1, proc_2]
 
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
 
@@ -202,8 +202,8 @@ def test_update_conditions_updates_pressures():
     plumb_eng.set_component_state('c1', 'open')
 
     s1 = top.ProcedureStep('s1', None, {top.Less(1, 75): top.Transition('p1', 's2')})
-    proc = top.Procedure('p1', {'s1': s1})
-    proc_suite = {'p1': proc}
+    proc = top.Procedure('p1', [s1])
+    proc_suite = [proc]
 
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
 
@@ -220,8 +220,8 @@ def test_update_conditions_updates_time():
     plumb_eng.set_component_state('c1', 'open')
 
     s1 = top.ProcedureStep('s1', None, {top.WaitUntil(1e6): 's2'})
-    proc = top.Procedure('p1', {'s1': s1})
-    proc_suite = {'p1': proc}
+    proc = top.Procedure('p1', [s1])
+    proc_suite = [proc]
 
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
 
@@ -259,8 +259,8 @@ def test_step_updates_conditions():
     plumb_eng.set_component_state('c1', 'open')
 
     s1 = top.ProcedureStep('s1', None, {top.Less(1, 75): 's2'})
-    proc = top.Procedure('p1', {'s1': s1})
-    proc_suite = {'p1': proc}
+    proc = top.Procedure('p1', [s1])
+    proc_suite = [proc]
 
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
 


### PR DESCRIPTION
Previously, a Procedure expected to receive steps as a dict of the form:

{'s1': s1, 's2': s2}

where s1 and s2 are ProcedureStep objects with step_id equal to 's1' and
's2', respectively.

This is unnecessarily verbose and makes it easier to accidentally
construct a procedure where the step keys do not correspond to the step
IDs. Instead, pass in a list [s1, s2], and have the Procedure construct
the dict by iterating over that list. This ensures that the keys will
always be equal to the step IDs.

ProceduresEngine did something similar with the procedure suite; this
has also been changed.

As a drive-by, also replace ======= with ------- in procedures code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/50)
<!-- Reviewable:end -->
