### PR TITLE
pdl: Add parser and more package functionality

### DIFF
--- a/topside/pdl/__init__.py
+++ b/topside/pdl/__init__.py
@@ -1,3 +1,4 @@
 from topside.pdl.exceptions import *
 from topside.pdl.file import *
 from topside.pdl.package import *
+from topside.pdl.parser import *

--- a/topside/pdl/example.yaml
+++ b/topside/pdl/example.yaml
@@ -100,7 +100,7 @@ body:
       fill_valve: closed
       vent_valve: open
       three_way_valve: left
-  
+
 - graph:
     name: secondary
     nodes:

--- a/topside/pdl/example.yaml
+++ b/topside/pdl/example.yaml
@@ -100,3 +100,15 @@ body:
       fill_valve: closed
       vent_valve: open
       three_way_valve: left
+  
+- graph:
+    name: secondary
+    nodes:
+      D:
+        components:
+          - [hole_valve, 0]
+      E:
+        components:
+          - [hole_valve, 1]
+    states:
+      hole_valve: open

--- a/topside/pdl/file.py
+++ b/topside/pdl/file.py
@@ -148,7 +148,7 @@ class File:
 
     def validate_graph(self, entry):
         """Validate graph entries specifically."""
-        check_fields(entry, ['name', 'nodes', 'states'])
+        check_fields(entry, ['name', 'nodes'])
         for node_name in entry['nodes']:
             node = entry['nodes'][node_name]
             if len(node) < 1 or 'components' not in node:

--- a/topside/pdl/file.py
+++ b/topside/pdl/file.py
@@ -28,7 +28,7 @@ class File:
           - body: the body of PDL.
 
         Parameters
-        ==========
+        ----------
 
         path: string
             path should contain either the path to the file containing PDL,
@@ -43,7 +43,7 @@ class File:
         initialization produces a ready-to-use File.
 
         Fields
-        ======
+        ------
 
         imports: list
             list of imports (by name) that are relevant to this file.

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -131,13 +131,18 @@ class Package:
         return ret
 
     def fill_graphs(self, graph):
+        """Fill in states field with default states if left blank."""
         ret = graph
         if 'states' not in graph:
             ret['states'] = {}
+
+        # set of components in this graph
         components = set()
         for node in graph['nodes'].values():
             for component in node['components']:
                 components.add(component[0])
+
+        # dict of {component: (namespace, index)} used to locate the component in self.components
         places = {}
         for namespace in self.components:
             for idx, component in enumerate(self.components[namespace]):
@@ -146,17 +151,22 @@ class Package:
         for component in components:
             if component in ret['states']:
                 continue
+
+            if component not in places:
+                raise exceptions.BadInputError(f"missing component {component}")
             namespace, idx = places[component]
             component_states = self.components[namespace][idx]['states']
+
             if len(component_states) != 1:
                 raise exceptions.BadInputError(
-                    f"state must be specified in graph {graph['name']} for component"+
+                    f"state must be specified in graph {graph['name']} for component" +
                     f" {component} with multiple states")
+
             state_name = list(component_states.keys())[0]
             ret['states'][component] = state_name
-        
+
         return ret
-            
+
 
 def unpack_teq(component):
     """Replace single-direction teq shortcut with verbose teq."""

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -27,10 +27,11 @@ class Package:
         a Package's PDL is cleaned and ready to use.
 
         Parameters
-        ==========
+        ----------
 
-        files: list
-            files is the list of one or more Files whose contents should go into the Package.
+        files: iterable
+            files is the iterable (usually a list) of one or more Files whose contents should go
+            into the Package.
         """
 
         if len(files) < 1:
@@ -89,7 +90,7 @@ class Package:
 
         for namespace, entries in self.graph_dict.items():
             for idx, graph in enumerate(entries):
-                self.graph_dict[namespace][idx] = self.fill_graphs(graph)
+                self.graph_dict[namespace][idx] = self.fillgraph_dict(graph)
 
     def rename(self):
         """Prepend any conflicting component names with namespace to disambiguate."""
@@ -133,7 +134,7 @@ class Package:
         ret['name'] = component_name
         return ret
 
-    def fill_graphs(self, graph):
+    def fillgraph_dict(self, graph):
         """Fill in states field with default states if left blank."""
         ret = graph
         if 'states' not in graph:

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -90,11 +90,15 @@ class Package:
 
         for namespace, entries in self.graph_dict.items():
             for idx, graph in enumerate(entries):
-                self.graph_dict[namespace][idx] = self.fillgraph_dict(graph)
+                self.graph_dict[namespace][idx] = self.fill_graphs(graph)
 
     def rename(self):
         """Prepend any conflicting component names with namespace to disambiguate."""
+
+        # record of {component name: namespace}
         names = {}
+
+        # record of which components were repeated (and need prepending)
         repeats = {}
         for namespace, entries in self.component_dict.items():
             for entry in entries:
@@ -114,8 +118,11 @@ class Package:
         """Fill in typedef template for components invoking a typedef."""
         name = component['type']
         component_name = component['name']
+
         if name.count('.') > 1:
             raise NotImplementedError(f"nested imports (in {name}) not supported yet")
+
+        # handle imported components
         if '.' in name:
             # NOTE: we might eventually want to consider how well this will play with nested imports
             fields = name.split('.')
@@ -123,6 +130,7 @@ class Package:
             name = fields[-1]
         if name not in self.typedefs[namespace]:
             raise exceptions.BadInputError(f"invalid component type: {name}")
+
         params = component['params']
         body = yaml.dump(self.typedefs[namespace][name])
 
@@ -134,9 +142,9 @@ class Package:
         ret['name'] = component_name
         return ret
 
-    def fillgraph_dict(self, graph):
+    def fill_graphs(self, graph):
         """Fill in states field with default states if left blank."""
-        ret = graph
+        ret = copy.deepcopy(graph)
         if 'states' not in graph:
             ret['states'] = {}
 

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -37,7 +37,7 @@ class Package:
             raise exceptions.BadInputError("cannot instantiate a Package with no Files")
         self.imports = []
 
-        # dicts of {namespace: entry}, where entry is a PDL object. Organized like this to
+        # dicts of {namespace: [entries]}, where entry is a PDL object. Organized like this to
         # reduce dict nesting; since this is a one time process it should be easy to keep
         # them synced.
         self.typedefs = {}
@@ -84,6 +84,24 @@ class Package:
 
                 # unpack single teq direction shortcuts
                 self.components[namespace][idx] = unpack_teq(component)
+
+        # prepend any conflicting names with namespace to disambiguate
+        names = {}
+        repeats = {}
+        for namespace, entries in self.components.items():
+            for entry in entries:
+                name = entry['name']
+                if name in names:
+                    repeats[name] = True
+                else:
+                    names[name] = namespace
+
+        for namespace, entries in self.components.items():
+            for idx, entry in enumerate(entries):
+                name = entry['name']
+                if name in repeats:
+                    self.components[namespace][idx]['name'] = namespace + '.' + name
+
 
     def fill_typedef(self, namespace, component):
         """Fill in typedef template for components invoking a typedef."""

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -1,8 +1,10 @@
 import copy
+import os
 import yaml
 
 import topside as top
 import topside.pdl.exceptions as exceptions
+import topside.pdl.utils as utils
 
 # imports is a dict of {package name: path to file}, used to locate files to load
 # on requested import.
@@ -11,7 +13,7 @@ import topside.pdl.exceptions as exceptions
 # outside a predefined library. Likely involves a function that traipses through the
 # imports folder for new files and stores them in this dict whenever new Packages are instantiated.
 IMPORTS = {
-    'stdlib': './topside/pdl/imports/stdlib.yaml'
+    'stdlib': os.path.join(utils.imports_path, "stdlib.yaml")
 }
 
 
@@ -30,11 +32,11 @@ class Package:
         ----------
 
         files: iterable
-            files is the iterable (usually a list) of one or more Files whose contents should go
+            files is an iterable (usually a list) of one or more Files whose contents should go
             into the Package.
         """
 
-        if len(files) < 1:
+        if len(list(files)) < 1:
             raise exceptions.BadInputError("cannot instantiate a Package with no Files")
         self.imports = []
 
@@ -89,14 +91,14 @@ class Package:
         self.rename()
 
         for namespace, entries in self.graph_dict.items():
-            for idx, graph in enumerate(entries):
-                self.graph_dict[namespace][idx] = self.fill_graphs(graph)
+            for entry in entries:
+                self.fill_blank_states(entry)
 
     def rename(self):
         """Prepend any conflicting component names with namespace to disambiguate."""
 
         # record of {component name: namespace}
-        names = {}
+        names = set()
 
         # record of which components were repeated (and need prepending)
         repeats = {}
@@ -106,7 +108,7 @@ class Package:
                 if name in names:
                     repeats[name] = True
                 else:
-                    names[name] = namespace
+                    names.add(name)
 
         for namespace, entries in self.component_dict.items():
             for idx, entry in enumerate(entries):
@@ -142,11 +144,12 @@ class Package:
         ret['name'] = component_name
         return ret
 
-    def fill_graphs(self, graph):
+    def fill_blank_states(self, graph):
         """Fill in states field with default states if left blank."""
-        ret = copy.deepcopy(graph)
         if 'states' not in graph:
-            ret['states'] = {}
+            graph['states'] = {}
+
+        default_states = self.get_default_states()
 
         # set of components in this graph
         components = set()
@@ -154,30 +157,33 @@ class Package:
             for component in node['components']:
                 components.add(component[0])
 
+        for component in components:
+            if component in graph['states']:
+                continue
+
+            if component not in default_states:
+                raise exceptions.BadInputError(
+                    f"missing component {component}: either a nonexistent or a"
+                    "multi-state component")
+
+            graph['states'][component] = default_states[component]
+
+    def get_default_states(self):
+        """Return a dict of {component_name: default state name} for one-state components"""
         # dict of {component:(namespace, index)} used to locate the component in self.component_dict
         places = {}
         for namespace in self.component_dict:
             for idx, component in enumerate(self.component_dict[namespace]):
                 places[component['name']] = (namespace, idx)
 
-        for component in components:
-            if component in ret['states']:
-                continue
-
-            if component not in places:
-                raise exceptions.BadInputError(f"missing component {component}")
-            namespace, idx = places[component]
+        default_states = {}
+        for component in self.components():
+            namespace, idx = places[component['name']]
             component_states = self.component_dict[namespace][idx]['states']
+            if len(component_states) == 1:
+                default_states[component["name"]] = list(component_states.keys())[0]
 
-            if len(component_states) != 1:
-                raise exceptions.BadInputError(
-                    f"state must be specified in graph {graph['name']} for component" +
-                    f" {component} with multiple states")
-
-            state_name = list(component_states.keys())[0]
-            ret['states'][component] = state_name
-
-        return ret
+        return default_states
 
     def components(self):
         """Return list of all component objects"""

--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -1,10 +1,10 @@
 import copy
 import os
+
 import yaml
 
 import topside as top
-import topside.pdl.exceptions as exceptions
-import topside.pdl.utils as utils
+from topside.pdl import exceptions, utils
 
 # imports is a dict of {package name: path to file}, used to locate files to load
 # on requested import.
@@ -13,7 +13,7 @@ import topside.pdl.utils as utils
 # outside a predefined library. Likely involves a function that traipses through the
 # imports folder for new files and stores them in this dict whenever new Packages are instantiated.
 IMPORTS = {
-    'stdlib': os.path.join(utils.imports_path, "stdlib.yaml")
+    'stdlib': os.path.join(utils.imports_path, 'stdlib.yaml')
 }
 
 
@@ -90,9 +90,11 @@ class Package:
 
         self.rename()
 
+        default_states = self.get_default_states()
+
         for namespace, entries in self.graph_dict.items():
             for entry in entries:
-                self.fill_blank_states(entry)
+                self.fill_blank_states(entry, default_states)
 
     def rename(self):
         """Prepend any conflicting component names with namespace to disambiguate."""
@@ -144,12 +146,10 @@ class Package:
         ret['name'] = component_name
         return ret
 
-    def fill_blank_states(self, graph):
+    def fill_blank_states(self, graph, default_states):
         """Fill in states field with default states if left blank."""
         if 'states' not in graph:
             graph['states'] = {}
-
-        default_states = self.get_default_states()
 
         # set of components in this graph
         components = set()

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -1,4 +1,5 @@
 import topside as top
+import topside.pdl.exceptions as exceptions
 
 
 class Parser:
@@ -10,6 +11,75 @@ class Parser:
         self.initial_pressure = {}
         self.initial_states = {}
 
+        self.parse_components()
+
     def parse_components(self):
-        # for entry in self.package.components.values():
-        pass
+        for entry in self.package.components():
+            name = entry['name']
+
+            edge_dict = extract_edges(entry)
+
+            edge_list = [edge[0] for edge in edge_dict.values()]
+            back_edge_list = [edge[1] for edge in edge_dict.values()]
+            edge_list.extend(back_edge_list)
+
+            states = {}
+            for state_name, edges in entry['states'].items():
+                edge_teqs = {}
+                for edge_name, teqs in edges.items():
+                    fwd_edge = edge_dict[edge_name][0]
+                    edge_teqs[fwd_edge] = teqs['fwd']
+
+                    back_edge = edge_dict[edge_name][1]
+                    edge_teqs[back_edge] = teqs['back']
+                states[state_name] = edge_teqs
+
+            component = top.PlumbingComponent(name, states, edge_list)
+            if not component.is_valid():
+                raise exceptions.BadInputError(f"errors in component {name} instantiation: {component.errors()}")
+            self.components.append(component)
+
+
+def extract_edges(entry):
+    name = entry['name']
+    edge_dict = {}
+
+    # edges_seen keeps track of edges between the same nodes. Takes form
+    # {(node1, node2): key}, where key is the lowest integer that has been used
+    # as a key for this set of nodes.
+    edges_seen = {}
+    for edge_name, edges in entry['edges'].items():
+        if len(edges['nodes']) != 2:
+            raise exceptions.BadInputError(
+                f"malformed nodes entry ({edges['nodes']}) for edge {edge_name} in" +
+                f" component {name}")
+        key = ""
+        nodes = tuple(edges['nodes'])
+        swapped_nodes = tuple(swap(edges['nodes']))
+        if nodes in edges_seen:
+            key = edges_seen[nodes]
+            edges_seen[nodes] += 1
+        elif swapped_nodes in edges_seen:
+            key = edges_seen[swapped_nodes]
+            edges_seen[swapped_nodes] += 1
+        else:
+            edges_seen[nodes] = 0
+
+        node_1 = edges['nodes'][0]
+        node_2 = edges['nodes'][1]
+
+        fwd_edge = (node_1, node_2, "fwd" + key)
+        back_edge = (node_2, node_1, "back" + key)
+
+        edge_dict[edge_name] = (fwd_edge, back_edge)
+
+    return edge_dict
+
+
+
+def swap(indexable):
+    """Take an indexable object and return a list of only its first two elements swapped."""
+    ret = []
+    ret.append(indexable[1])
+    ret.append(indexable[0])
+    return ret

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -1,0 +1,15 @@
+import topside as top
+
+
+class Parser:
+    def __init__(self, files):
+        self.package = top.Package(files)
+
+        self.components = []
+        self.mapping = {}
+        self.initial_pressure = {}
+        self.initial_states = {}
+
+    def parse_components(self):
+        # for entry in self.package.components.values():
+        pass

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -5,7 +5,22 @@ import topside.pdl.exceptions as exceptions
 
 
 class Parser:
+    """Produces plumbing engine input representative of its given files."""
+
     def __init__(self, files):
+        """
+        Initialize a parser from one or more Files.
+
+        A Parser contains a Package; most of its functionality lies in restructuring the data
+        contained in its Package into output suitable for loading a Plumbing Engine.
+
+        Parameters
+        ----------
+
+        files: iterable
+            files is the iterable (usually a list) of one or more Files whose contents should go
+            into the Parser.
+        """
         self.package = top.Package(files)
 
         self.components = {}
@@ -17,6 +32,7 @@ class Parser:
         self.parse_graphs()
 
     def parse_components(self):
+        """Create and store components for plumbing engine."""
         for entry in self.package.components():
             name = entry['name']
 
@@ -48,6 +64,7 @@ class Parser:
             self.components[name] = component
 
     def parse_graphs(self):
+        """Extract and store graph information for plumbing engine."""
         graphs = self.package.graphs()
         main_present = False
 
@@ -98,19 +115,19 @@ def extract_edges(entry):
         nodes = tuple(edges['nodes'])
         swapped_nodes = tuple(swap(edges['nodes'], 0, 1))
         if nodes in edges_seen:
-            key = edges_seen[nodes]
             edges_seen[nodes] += 1
+            key = edges_seen[nodes]
         elif swapped_nodes in edges_seen:
-            key = edges_seen[swapped_nodes]
             edges_seen[swapped_nodes] += 1
+            key = edges_seen[swapped_nodes]
         else:
-            edges_seen[nodes] = 0
+            edges_seen[nodes] = 1
 
         node_1 = edges['nodes'][0]
         node_2 = edges['nodes'][1]
 
-        fwd_edge = (node_1, node_2, "fwd" + key)
-        back_edge = (node_2, node_1, "back" + key)
+        fwd_edge = (node_1, node_2, "fwd" + str(key))
+        back_edge = (node_2, node_1, "back" + str(key))
 
         edge_dict[edge_name] = (fwd_edge, back_edge)
 
@@ -122,7 +139,7 @@ def swap(indexable, idx1, idx2):
     if len(indexable) <= max(idx1, idx2):
         raise exceptions.BadInputError(
             f"len indexable ({len(indexable)}, {indexable} less than index {max(idx1, idx2)}")
-    ret = copy.deepcopy(indexable)
+    ret = list(copy.deepcopy(indexable))
     temp = ret[idx1]
     ret[idx1] = ret[idx2]
     ret[idx2] = temp

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -58,9 +58,6 @@ class Parser:
                 states[state_name] = edge_teqs
 
             component = top.PlumbingComponent(name, states, edge_list)
-            if not component.is_valid():
-                raise exceptions.BadInputError(
-                    f"errors in component {name} instantiation: {component.errors()}")
             self.components[name] = component
 
     def parse_graphs(self):
@@ -72,7 +69,7 @@ class Parser:
         for idx, entry in enumerate(graphs):
             if entry['name'] == 'main':
                 main_present = True
-                swap(graphs, -1, idx)
+                graphs = swap(graphs, -1, idx)
         if not main_present:
             raise exceptions.BadInputError("must have graph main")
 
@@ -92,6 +89,12 @@ class Parser:
                     self.mapping[component_name][component_node] = graph_node
 
             self.initial_states.update(entry['states'])
+
+    def make_engine(self):
+        """Create the plumbing engine from the provided input."""
+        plumb = top.PlumbingEngine(self.components, self.mapping,
+                                   self.initial_pressures, self.initial_states)
+        return plumb
 
 
 def extract_edges(entry):

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -5,14 +5,14 @@ import topside.pdl.exceptions as exceptions
 
 
 class Parser:
-    """Produces plumbing engine input representative of its given files."""
+    """Produces plumbing engine input that's representative of its given files."""
 
     def __init__(self, files):
         """
         Initialize a parser from one or more Files.
 
         A Parser contains a Package; most of its functionality lies in restructuring the data
-        contained in its Package into output suitable for loading a Plumbing Engine.
+        contained in its Package into output suitable for loading a plumbing engine.
 
         Parameters
         ----------
@@ -36,7 +36,7 @@ class Parser:
         for entry in self.package.components():
             name = entry['name']
 
-            # extract edge list, plus dict keyed by name
+            # extract edge list, plus dict of {edge name: edge tuple}
             edge_dict = extract_edges(entry)
             edge_list = []
             fwd_edge_list = [edge[0] for edge in edge_dict.values()]
@@ -95,7 +95,12 @@ class Parser:
 
 
 def extract_edges(entry):
-    """Extract dict of {edge_name: (fwd_edge, back_edge)} from a component entry."""
+    """
+    Extract dict of {edge_name: (fwd_edge, back_edge)} from a component entry.
+
+    fwd_edge and back_edge take the form (node1, node2, key), where key is unique among
+    edges going between the same nodes.
+    """
     name = entry['name']
     edge_dict = {}
 
@@ -135,7 +140,7 @@ def extract_edges(entry):
 
 
 def swap(indexable, idx1, idx2):
-    """Take an indexable object and return a list of only its first two elements swapped."""
+    """Take an indexable object and return a list with its elements swapped at the given indices."""
     if len(indexable) <= max(idx1, idx2):
         raise exceptions.BadInputError(
             f"len indexable ({len(indexable)}, {indexable} less than index {max(idx1, idx2)}")

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -12,7 +12,7 @@ def test_valid_pdl():
 
     assert len(file.typedefs) == 1
     assert len(file.components) == 6
-    assert len(file.graphs) == 1
+    assert len(file.graphs) == 2
 
 
 def test_no_import():
@@ -155,29 +155,6 @@ body:
 """
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(no_hoisting, input_type='s')
-
-
-def test_invalid_graph():
-    # missing the field specifying which state each component should take initially
-    missing_states =\
-        """
-name: example
-import: [stdlib]
-body:
-- graph:
-    name: main
-    nodes:
-      A:
-        fixed_pressure: 500
-        components:
-          - [fill_valve, 0]
-
-      B:
-        components:
-          - [fill_valve, 1]
-"""
-    with pytest.raises(exceptions.BadInputError):
-        _ = top.File(missing_states, 's')
 
 
 def test_invalid_incomplete_node():

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -2,10 +2,11 @@ import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions
+import topside.pdl.utils as utils
 
 
 def test_valid_pdl():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
 
     assert file.namespace == 'example'
     assert file.imports == ['stdlib']

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -74,10 +74,11 @@ def test_files_unchanged():
 
 
 def test_invalid_import():
+    bad_import = "NONEXISTENT"
     invalid_import =\
-        """
+        f"""
 name: example
-import: [stdlib, NONEXISTENT]
+import: [stdlib, {bad_import}]
 body:
 - typedef:
     params: [edge1, open_teq, closed_teq]
@@ -100,14 +101,15 @@ def test_invalid_bad_import_type():
     # typedef not found errors having to do with imported files will only be caught at the package
     # level, not at the file one. We can look at changing this if we change the implementation of
     # how importable files are stored.
+    bad_type = "NONEXISTENT_TYPE"
     bad_imported_type =\
-        """
+        f"""
 name: example
 import: [stdlib]
 body:
 - component:
     name: vent_valve
-    type: stdlib.NONEXISTENT_TYPE
+    type: stdlib.{bad_type}
     params:
       edge_name: fav_edge
       open_teq: 5

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -64,11 +64,12 @@ def test_package_shortcuts():
 def test_files_unchanged():
     file = top.File('topside/pdl/example.yaml')
 
-    _ = top.Package([file])
+    top.Package([file])
 
     assert len(file.typedefs) == 1
     assert len(file.components) == 6
     assert len(file.graphs) == 2
+
 
 test_files_unchanged()
 
@@ -93,7 +94,7 @@ body:
 """
     invalid_import_file = top.File(invalid_import, input_type='s')
     with pytest.raises(exceptions.BadInputError):
-        _ = top.Package([invalid_import_file])
+        top.Package([invalid_import_file])
 
 
 def test_invalid_bad_import_type():
@@ -115,12 +116,12 @@ body:
 """
     bad_imported_type_file = top.File(bad_imported_type, input_type='s')
     with pytest.raises(exceptions.BadInputError):
-        _ = top.Package([bad_imported_type_file])
+        top.Package([bad_imported_type_file])
 
 
 def test_invalid_empty_package():
     with pytest.raises(exceptions.BadInputError):
-        _ = top.Package([])
+        top.Package([])
 
 
 def test_invalid_nested_import():
@@ -138,7 +139,7 @@ body:
 """
     nested_import_file = top.File(nested_import, input_type='s')
     with pytest.raises(NotImplementedError):
-        _ = top.Package([nested_import_file])
+        top.Package([nested_import_file])
 
 
 def test_duplicate_names():
@@ -180,7 +181,7 @@ body:
 
 def test_invalid_graph_missing_states():
     missing_states =\
-    """
+        """
 name: example
 import: [stdlib]
 body:

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -2,10 +2,11 @@ import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions
+import topside.pdl.utils as utils
 
 
 def test_package_storage():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
 
     pack = top.Package([file])
 
@@ -26,7 +27,7 @@ def test_package_storage():
 
 
 def test_package_typedefs():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
     namespace = file.namespace
 
     pack = top.Package([file])
@@ -52,7 +53,7 @@ def test_package_typedefs():
 
 
 def test_package_shortcuts():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
     namespace = file.namespace
 
     pack = top.Package([file])
@@ -64,7 +65,7 @@ def test_package_shortcuts():
 
 
 def test_files_unchanged():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
 
     top.Package([file])
 

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -13,14 +13,16 @@ def test_package_storage():
     assert len(pack.typedefs) == 2
     assert 'example' in pack.typedefs and 'stdlib' in pack.typedefs
 
-    assert len(pack.components[namespace]) == 6
-    assert len(pack.components['stdlib']) == 0
+    assert len(pack.component_dict[namespace]) == 6
+    assert len(pack.component_dict['stdlib']) == 0
+    assert len(pack.components()) == 6
 
     assert len(pack.typedefs[namespace]) == 1
     assert len(pack.typedefs['stdlib']) == 1
 
-    assert len(pack.graphs[namespace]) == 2
-    assert len(pack.graphs['stdlib']) == 0
+    assert len(pack.graph_dict[namespace]) == 2
+    assert len(pack.graph_dict['stdlib']) == 0
+    assert len(pack.graphs()) == 2
 
 
 def test_package_typedefs():
@@ -33,7 +35,7 @@ def test_package_typedefs():
     var_closed = 'closed_teq'
     var_name = 'edge_name'
 
-    for component in pack.components[namespace]:
+    for component in pack.component_dict[namespace]:
         # ensure typedef fulfillment occurred
         assert 'type' not in component and 'params' not in component
         assert 'edges' in component
@@ -54,7 +56,7 @@ def test_package_shortcuts():
     namespace = file.namespace
 
     pack = top.Package([file])
-    for component in pack.components[namespace]:
+    for component in pack.component_dict[namespace]:
         assert 'states' in component
         for edges in component['states'].values():
             for teq in edges.values():
@@ -69,9 +71,6 @@ def test_files_unchanged():
     assert len(file.typedefs) == 1
     assert len(file.components) == 6
     assert len(file.graphs) == 2
-
-
-test_files_unchanged()
 
 
 def test_invalid_import():
@@ -175,8 +174,8 @@ body:
         edge1: closed
 """
     duplicate_pack = top.Package([top.File(file_1, 's'), top.File(file_2, 's')])
-    assert duplicate_pack.components["name1"][0]['name'] == "name1.fill_valve"
-    assert duplicate_pack.components["name2"][0]['name'] == "name2.fill_valve"
+    assert duplicate_pack.component_dict["name1"][0]['name'] == "name1.fill_valve"
+    assert duplicate_pack.component_dict["name2"][0]['name'] == "name2.fill_valve"
 
 
 def test_invalid_graph_missing_states():

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -19,7 +19,7 @@ def test_package_storage():
     assert len(pack.typedefs[namespace]) == 1
     assert len(pack.typedefs['stdlib']) == 1
 
-    assert len(pack.graphs[namespace]) == 1
+    assert len(pack.graphs[namespace]) == 2
     assert len(pack.graphs['stdlib']) == 0
 
 
@@ -68,7 +68,9 @@ def test_files_unchanged():
 
     assert len(file.typedefs) == 1
     assert len(file.components) == 6
-    assert len(file.graphs) == 1
+    assert len(file.graphs) == 2
+
+test_files_unchanged()
 
 
 def test_invalid_import():
@@ -123,7 +125,7 @@ def test_invalid_empty_package():
 
 def test_invalid_nested_import():
     nested_import =\
-            """
+        """
 name: example
 import: [stdlib]
 body:
@@ -174,3 +176,36 @@ body:
     duplicate_pack = top.Package([top.File(file_1, 's'), top.File(file_2, 's')])
     assert duplicate_pack.components["name1"][0]['name'] == "name1.fill_valve"
     assert duplicate_pack.components["name2"][0]['name'] == "name2.fill_valve"
+
+
+def test_invalid_graph_missing_states():
+    missing_states =\
+    """
+name: example
+import: [stdlib]
+body:
+- component:
+    name: fill_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      open:
+        edge1: 6
+      closed:
+        edge1: closed
+- graph:
+    name: main
+    nodes:
+      A:
+        fixed_pressure: 500
+        components:
+          - [fill_valve, 0]
+
+      B:
+        components:
+          - [fill_valve, 1]
+"""
+    missing_states_file = top.File(missing_states, 's')
+    with pytest.raises(exceptions.BadInputError):
+        top.Package([missing_states_file])

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -137,3 +137,40 @@ body:
     nested_import_file = top.File(nested_import, input_type='s')
     with pytest.raises(NotImplementedError):
         _ = top.Package([nested_import_file])
+
+
+def test_duplicate_names():
+    file_1 =\
+        """
+name: name1
+body:
+- component:
+    name: fill_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      open:
+        edge1: 6
+      closed:
+        edge1: closed
+"""
+
+    file_2 =\
+        """
+name: name2
+body:
+- component:
+    name: fill_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      open:
+        edge1: 6
+      closed:
+        edge1: closed
+"""
+    duplicate_pack = top.Package([top.File(file_1, 's'), top.File(file_2, 's')])
+    assert duplicate_pack.components["name1"][0]['name'] == "name1.fill_valve"
+    assert duplicate_pack.components["name2"][0]['name'] == "name2.fill_valve"

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -1,10 +1,58 @@
 import topside as top
 
+
 def test_valid_file():
     file = top.File('topside/pdl/example.yaml')
 
     parsed = top.Parser([file])
 
     assert len(parsed.components) == 6
-    for component in parsed.components:
+    for component in parsed.components.values():
         assert component.is_valid()
+
+    assert parsed.initial_pressures == {
+        'A': (500, True),
+        'C': (10, False)
+    }
+
+    assert parsed.initial_states == {
+        'fill_valve': 'closed',
+        'vent_valve': 'open',
+        'three_way_valve': 'left',
+        'hole_valve': 'open',
+        'vent_plug': 'default',
+        'check_valve': 'default'
+    }
+
+    assert parsed.mapping == {
+        'fill_valve': {
+            0: 'A',
+            1: 'B'
+        },
+        'vent_valve': {
+            0: 'B',
+            1: 'atm'
+        },
+        'three_way_valve': {
+            0: 'C',
+            1: 'D',
+            2: 'atm'
+        },
+        'hole_valve': {
+            0: 'D',
+            1: 'E'
+        },
+        'vent_plug': {
+            0: 'D',
+            1: 'atm'
+        },
+        'check_valve': {
+            0: 'B',
+            1: 'C',
+        }
+    }
+
+    plumb = top.PlumbingEngine(
+        parsed.components, parsed.mapping, parsed.initial_pressures, parsed.initial_states)
+
+    assert plumb.is_valid()

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -1,4 +1,32 @@
+import pytest
+
 import topside as top
+import topside.pdl.exceptions as exceptions
+
+
+def test_swap():
+    list_3 = [1, 2, 3]
+    assert top.swap(list_3, 0, 2) == [3, 2, 1]
+    # index order doesn't matter
+    assert top.swap(list_3, 2, 0) == top.swap(list_3, 0, 2)
+
+    list_2 = [1, 2]
+    assert top.swap(list_2, 1, 0) == [2, 1]
+
+    # original list remains unchanged
+    assert list_3 == [1, 2, 3]
+
+    tuple_3 = (1, 2, 3)
+    tuple_2 = (1, 2)
+    assert top.swap(tuple_3, 1, 0) == [2, 1, 3]
+    assert top.swap(tuple_2, 1, 0) == [2, 1]
+
+    list_1 = [1]
+    assert top.swap(list_1, 0, 0) == [1]
+
+    # swap index exceeds list length
+    with pytest.raises(exceptions.BadInputError):
+        top.swap(list_1, 0, 1)
 
 
 def test_valid_file():
@@ -56,3 +84,158 @@ def test_valid_file():
         parsed.components, parsed.mapping, parsed.initial_pressures, parsed.initial_states)
 
     assert plumb.is_valid()
+
+    assert len(plumb.nodes()) == 6
+    assert set(plumb.nodes(data=False)) == {'A', 'B', 'C', 'D', 'E', 'atm'}
+
+    assert plumb.current_state() == parsed.initial_states
+    assert plumb.current_pressures() == {
+        'A': 500,
+        'B': 0,
+        'C': 10,
+        'D': 0,
+        'E': 0,
+        'atm': 0
+    }
+
+
+def test_invalid_main():
+    not_main = "NOT MAIN"
+    no_main_graph =\
+        f"""
+name: example
+import: [stdlib]
+body:
+- component:
+    name: fill_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      open:
+        edge1: 6
+      closed:
+        edge1: closed
+- graph:
+    name: {not_main}
+    nodes:
+      A:
+        fixed_pressure: 500
+        components:
+          - [fill_valve, 0]
+
+      B:
+        components:
+          - [fill_valve, 1]
+    states:
+        fill_valve: open
+"""
+    no_main_file = top.File(no_main_graph, 's')
+    with pytest.raises(exceptions.BadInputError):
+        top.Parser([no_main_file])
+
+
+def test_invalid_component():
+    low_teq = 0.000000001
+    teq_too_low =\
+        f"""
+name: example
+import: [stdlib]
+body:
+- component:
+    name: fill_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      open:
+        edge1: {low_teq}
+      closed:
+        edge1: closed
+- graph:
+    name: main
+    nodes:
+      A:
+        fixed_pressure: 500
+        components:
+          - [fill_valve, 0]
+
+      B:
+        components:
+          - [fill_valve, 1]
+    states:
+      fill_valve: open
+    """
+
+    teq_low_file = top.File(teq_too_low, 's')
+    with pytest.raises(exceptions.BadInputError):
+        top.Parser([teq_low_file])
+
+
+def test_standard_extract_edges():
+    standard_entry = {
+        'name': 'example',
+        'edges': {
+            'edge1': {
+                'nodes': [0, 1]
+            },
+            'edge2': {
+                'nodes': [1, 2]
+            }
+        }
+    }
+
+    extracted_standard_entry = top.extract_edges(standard_entry)
+    assert extracted_standard_entry == {
+        'edge1': (
+            (0, 1, 'fwd'),
+            (1, 0, 'back')
+        ),
+        'edge2': (
+            (1, 2, 'fwd'),
+            (2, 1, 'back')
+        )
+    }
+
+
+def test_extract_repeated_edges():
+    repeated_entry = {
+        'name': 'example',
+        'edges': {
+            'edge1': {
+                'nodes': [0, 1]
+            },
+            'edge2': {
+                'nodes': [1, 0]
+            }
+        }
+    }
+
+    extracted_repeat_entry = top.extract_edges(repeated_entry)
+    assert extracted_repeat_entry == {
+        'edge1': (
+            (0, 1, 'fwd'),
+            (1, 0, 'back')
+        ),
+        'edge2': (
+            (1, 0, 'fwd2'),
+            (0, 1, 'back2')
+        )
+    }
+
+
+def test_invalid_extract_edges():
+    invalid_entry = {
+        'name': 'example',
+        'edges': {
+            'edge1': {
+                'nodes': [0, 1, 2]
+            },
+            'edge2': {
+                'nodes': [1, 0]
+            }
+        }
+    }
+
+    with pytest.raises(exceptions.BadInputError):
+        top.extract_edges(invalid_entry)

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -1,0 +1,10 @@
+import topside as top
+
+def test_valid_file():
+    file = top.File('topside/pdl/example.yaml')
+
+    parsed = top.Parser([file])
+
+    assert len(parsed.components) == 6
+    for component in parsed.components:
+        assert component.is_valid()

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -80,8 +80,10 @@ def test_valid_file():
         }
     }
 
-    plumb = top.PlumbingEngine(
-        parsed.components, parsed.mapping, parsed.initial_pressures, parsed.initial_states)
+    for component in parsed.components.values():
+        assert component.is_valid()
+
+    plumb = parsed.make_engine()
 
     assert plumb.is_valid()
 
@@ -140,7 +142,6 @@ def test_invalid_component():
     teq_too_low =\
         f"""
 name: example
-import: [stdlib]
 body:
 - component:
     name: fill_valve
@@ -168,8 +169,11 @@ body:
     """
 
     teq_low_file = top.File(teq_too_low, 's')
-    with pytest.raises(exceptions.BadInputError):
-        top.Parser([teq_low_file])
+    # this shouldn't raise an error, invalid components are legal
+    parse = top.Parser([teq_low_file])
+
+    plumb = parse.make_engine()
+    assert not plumb.is_valid()
 
 
 def test_standard_extract_edges():

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -2,35 +2,11 @@ import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions
-
-
-def test_swap():
-    list_3 = [1, 2, 3]
-    assert top.swap(list_3, 0, 2) == [3, 2, 1]
-    # index order doesn't matter
-    assert top.swap(list_3, 2, 0) == top.swap(list_3, 0, 2)
-
-    list_2 = [1, 2]
-    assert top.swap(list_2, 1, 0) == [2, 1]
-
-    # original list remains unchanged
-    assert list_3 == [1, 2, 3]
-
-    tuple_3 = (1, 2, 3)
-    tuple_2 = (1, 2)
-    assert top.swap(tuple_3, 1, 0) == [2, 1, 3]
-    assert top.swap(tuple_2, 1, 0) == [2, 1]
-
-    list_1 = [1]
-    assert top.swap(list_1, 0, 0) == [1]
-
-    # swap index exceeds list length
-    with pytest.raises(exceptions.BadInputError):
-        top.swap(list_1, 0, 1)
+import topside.pdl.utils as utils
 
 
 def test_valid_file():
-    file = top.File('topside/pdl/example.yaml')
+    file = top.File(utils.example_path)
 
     parsed = top.Parser([file])
 

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -225,7 +225,7 @@ def test_extract_repeated_edges():
 
 
 def test_invalid_extract_edges():
-    invalid_entry = {
+    too_many_nodes = {
         'name': 'example',
         'edges': {
             'edge1': {
@@ -238,4 +238,4 @@ def test_invalid_extract_edges():
     }
 
     with pytest.raises(exceptions.BadInputError):
-        top.extract_edges(invalid_entry)
+        top.extract_edges(too_many_nodes)

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -78,7 +78,7 @@ def test_valid_file():
 
 
 def test_invalid_main():
-    not_main = "NOT MAIN"
+    not_main = "NOT_MAIN"
     no_main_graph =\
         f"""
 name: example

--- a/topside/pdl/utils.py
+++ b/topside/pdl/utils.py
@@ -1,0 +1,5 @@
+import os
+
+pdl_path = os.path.dirname(__file__)
+example_path = os.path.join(pdl_path, "example.yaml")
+imports_path = os.path.join(pdl_path, "imports")

--- a/topside/plumbing/plumbing_engine.py
+++ b/topside/plumbing/plumbing_engine.py
@@ -101,7 +101,6 @@ class PlumbingEngine:
                     f"Component with name '{name}' is not valid;"
                     " component cannot be loaded in until errors are resolved.", name)
                 invalid.add_error(error, self.error_set)
-                continue
             name_valid = True
             if name not in self.mapping:
                 error = invalid.InvalidComponentName(

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -147,7 +147,7 @@ def test_invalid_component():
     assert str(err.value) == "Node 1 not found in graph."
 
     assert not plumb.is_valid()
-    assert len(plumb.errors()) == 1
+    assert len(plumb.errors()) == 2
 
     error = invalid.InvalidComponentName(
         "Component with name 'valve' is not valid;"


### PR DESCRIPTION
Adds in the parser, which takes package data and extracts it into forms suitable for loading into a PlumbingEngine. This PR also includes a few features on `Package` that were necessary to make the parser work, namely:
* prepending namespaces on conflicting component names
* elaborating the states field in `graph` entries (as part of PDL cleanup)

Namespacing in graphs still hasn't been implemented in this PR, I'll make it part of a followup PR instead. The basic version we have now is combine all nodes named the same across all graphs/files/imports, with the `main` graph taking precedence. I've put some preliminary planning for an actual namespacing system in the dev notes, but there are still some details to flesh out in that model.

Also did a drive-by replace of `=` with `-` for parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/51)
<!-- Reviewable:end -->
