### PR TITLE
Print test coverage in CI

### DIFF
--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
+        pip install pytest-cov
         pip install -r requirements.txt
 
     - name: Lint with flake8
@@ -49,7 +50,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov=topside
 
     - name: Build and run application
       run: |

--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install wheel
         pip install flake8
         pip install pytest-cov
         pip install -r requirements.txt


### PR DESCRIPTION
Pretty trivial change, this just uses `pytest-cov` to also print test coverage in CI. It's more out of curiosity than anything significant, but I thought it could be a cool metric to poke while waiting for CI to pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/52)
<!-- Reviewable:end -->
