### PR TITLE
Use ProceduresEngine in application

### DIFF
--- a/application/procedures_bridge.py
+++ b/application/procedures_bridge.py
@@ -1,18 +1,61 @@
 from PySide2.QtCore import Qt, Slot, Signal, Property, \
     QObject, QAbstractListModel, QModelIndex
 
+import topside as top
+
+
+# TODO(jacob): Delete this test code and load a real engine and procedure
+
+class MockPlumbingEngine:
+    def __init__(self):
+        pass
+
+    def step(self, dt):
+        pass
+
+    def set_component_state(self, component, state):
+        pass
+
+    def current_pressures(self):
+        return {}
+
+
+def build_test_procedure_suite():
+    open_action_1 = top.Action('c1', 'open')
+    open_action_2 = top.Action('c2', 'open')
+    close_action_1 = top.Action('c1', 'close')
+    close_action_2 = top.Action('c2', 'close')
+
+    s1 = top.ProcedureStep('s1', open_action_1, {top.Immediate(): top.Transition('p1', 's2')})
+    s2 = top.ProcedureStep('s2', open_action_2, {top.Immediate(): top.Transition('p2', 's3')})
+
+    p1 = top.Procedure('p1', [s1, s2])
+
+    s3 = top.ProcedureStep('s3', close_action_1, {top.Immediate(): top.Transition('p2', 's4')})
+    s4 = top.ProcedureStep('s4', close_action_2, {top.Immediate(): top.Transition('p1', 's1')})
+
+    p2 = top.Procedure('p2', [s3, s4])
+
+    return [p1, p2]
+
 
 class ProcedureStepsModel(QAbstractListModel):
     PersonRoleIdx = Qt.UserRole + 1
     StepRoleIdx = Qt.UserRole + 2
 
-    def __init__(self, steps, parent=None):
+    def __init__(self, procedure, parent=None):
         QAbstractListModel.__init__(self, parent)
-        self.steps = steps
-        self.idx = 0
+        self.procedure = procedure
+
+    def change_procedure(self, new_procedure):
+        self.layoutAboutToBeChanged.emit()
+        self.procedure = new_procedure
+        self.layoutChanged.emit()
+
+    # Qt accessible methods
 
     def rowCount(self, parent=QModelIndex()):
-        return len(self.steps)
+        return len(self.procedure.steps)
 
     def roleNames(self):
         # NOTE(jacob): The values in this dict are byte strings instead
@@ -29,56 +72,45 @@ class ProcedureStepsModel(QAbstractListModel):
         if role == ProcedureStepsModel.PersonRoleIdx:
             return 'Primary Technician'
         elif role == ProcedureStepsModel.StepRoleIdx:
-            return self.steps[index.row()]
+            step = list(self.procedure.steps.values())[index.row()]
+            action = step.action
+            return f'Set {action.component} to {action.state}'
         return None
 
-    def stop(self):
-        self.idx = 0
 
-    def previous_step(self):
-        if self.idx > 0:
-            self.idx -= 1
-
-    def next_step(self):
-        if self.idx < self.rowCount() - 1:
-            self.idx += 1
-
-    def append_step(self, step):
-        row_idx = self.rowCount()
-        self.beginInsertRows(QModelIndex(), row_idx, row_idx)
-        self.steps.append(step)
-        self.endInsertRows()
-
-
-# TODO(jacob): Once the procedures engine exists and the internal logic
-# is a bit more fleshed out, investigate if we really need a separate
-# bridge class or if we can connect the signals directly to the model.
 class ProceduresBridge(QObject):
     goto_step_sig = Signal(int, name='gotoStep')
-    steps_changed_sig = Signal(name='stepsChanged')
+    steps_changed_sig = Signal(name='dataChanged')
 
     def __init__(self):
         QObject.__init__(self)
 
-        self._procedure_steps = ProcedureStepsModel([
-            'Open Series Fill Valve',
-            'Open Line Vent Valve',
-            'Retreat to Mission Control',
-            'Open Injector Valve',
-        ])
+        plumb = MockPlumbingEngine()
+        suite = build_test_procedure_suite()
+
+        self._procedures_engine = top.ProceduresEngine(plumb, suite, 'p1', 's1')
+        self._procedure_steps = ProcedureStepsModel(self._procedures_engine.current_procedure())
+
+    def _refresh_procedure_view(self):
+        proc = self._procedures_engine.current_procedure()
+
+        if self._procedure_steps.procedure.procedure_id != proc.procedure_id:
+            self._procedure_steps.change_procedure(proc)
+
+        idx = proc.index_of(self._procedures_engine.current_step.step_id)
+        self.goto_step_sig.emit(idx)
 
     @Property(QObject, notify=steps_changed_sig)
     def steps(self):
         return self._procedure_steps
 
     @Slot()
-    def play_backwards(self):
+    def playBackwards(self):
         pass
 
     @Slot()
     def undo(self):
-        self._procedure_steps.previous_step()
-        self.goto_step_sig.emit(self._procedure_steps.idx)
+        pass
 
     @Slot()
     def play(self):
@@ -90,14 +122,13 @@ class ProceduresBridge(QObject):
 
     @Slot()
     def stop(self):
-        self._procedure_steps.stop()
-        self.goto_step_sig.emit(self._procedure_steps.idx)
+        pass
 
     @Slot()
-    def step_forward(self):
-        self._procedure_steps.next_step()
-        self.goto_step_sig.emit(self._procedure_steps.idx)
+    def stepForward(self):
+        self._procedures_engine.next_step()
+        self._refresh_procedure_view()
 
     @Slot()
     def advance(self):
-        self._procedure_steps.append_step('Close Injector Valve')
+        pass

--- a/application/procedures_bridge.py
+++ b/application/procedures_bridge.py
@@ -69,10 +69,13 @@ class ProcedureStepsModel(QAbstractListModel):
         }
 
     def data(self, index, role):
+        try:
+            step = self.procedure.step_list[index.row()]
+        except IndexError:
+            return 'Invalid Index'
         if role == ProcedureStepsModel.PersonRoleIdx:
             return 'Primary Technician'
         elif role == ProcedureStepsModel.StepRoleIdx:
-            step = list(self.procedure.steps.values())[index.row()]
             action = step.action
             return f'Set {action.component} to {action.state}'
         return None

--- a/application/resources/ProceduresPane.qml
+++ b/application/resources/ProceduresPane.qml
@@ -92,7 +92,7 @@ ColumnLayout {
                 icon.source: "themes/default/play_backwards.png"
                 icon.color: "transparent"
 
-                onClicked: proceduresBridge.play_backwards()
+                onClicked: proceduresBridge.playBackwards()
             }
             Button {
                 Layout.alignment: Qt.AlignVCenter
@@ -136,7 +136,14 @@ ColumnLayout {
                 icon.source: "themes/default/step_forward.png"
                 icon.color: "transparent"
 
-                onClicked: proceduresBridge.step_forward()
+                // TODO(jacob): We connect both clicked and doubleClicked to stepForward because
+                // there seems to be some sort of debouncing/delay built in that prevents clicking
+                // twice in quick succession from advancing steps twice. For now, we choose to
+                // explicitly recognize a double click as identical to a click. Investigate if this
+                // is really the best way to do things or if there's a better way to get rid of the
+                // delay.
+                onClicked: proceduresBridge.stepForward()
+                onDoubleClicked: proceduresBridge.stepForward()
             }
             Button {
                 Layout.alignment: Qt.AlignVCenter
@@ -154,7 +161,7 @@ ColumnLayout {
         id: procedureStepDelegate
 
         RowLayout {
-            width: parent.width
+            width: proceduresList.width
             spacing: 10
             
             Text {

--- a/application/resources/ProceduresPane.qml
+++ b/application/resources/ProceduresPane.qml
@@ -163,7 +163,7 @@ ColumnLayout {
         RowLayout {
             width: proceduresList.width
             spacing: 10
-            
+
             Text {
                 text: model.index + 1 + "."
                 font.bold: true

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -88,4 +88,30 @@ class Procedure:
             to last step.
         """
         self.procedure_id = procedure_id
-        self.steps = {step.step_id: step for step in steps}
+        self.steps = {}
+        self.step_id_to_idx = {}
+
+        for i, step in enumerate(steps):
+            if step.step_id in self.steps:
+                raise ValueError(
+                    f'duplicate step ID {step.step_id} encountered in Procedure initialization')
+            self.steps[step.step_id] = step
+            self.step_id_to_idx[step.step_id] = i
+
+    def index_of(self, step_id):
+        """
+        Given the ID for a step, return the index at which that step is found.
+
+        Parameters
+        ----------
+        step_id: str
+            The identifier for the step for which the index is desired.
+
+        Returns
+        -------
+
+        idx: int
+            The positional index of the step with id step_id in this
+            procedure.
+        """
+        return self.step_id_to_idx[step_id]

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -89,6 +89,7 @@ class Procedure:
         """
         self.procedure_id = procedure_id
         self.steps = {}
+        self.step_list = list(steps)
         self.step_id_to_idx = {}
 
         for i, step in enumerate(steps):

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -86,7 +86,7 @@ class ProceduresEngine:
                 self.execute(self.current_step.action)
                 break
 
-    def step(self, timestep=None):
+    def step_time(self, timestep=None):
         """
         Step the managed plumbing engine in time and update conditions.
 
@@ -103,3 +103,7 @@ class ProceduresEngine:
         # TODO(jacob): Consider if this function should return anything
         # about the state of the system: plumbing engine state, current
         # time, etc.
+
+    def current_procedure(self):
+        """Return the procedure currently being executed."""
+        return self._procedure_suite[self.current_procedure_id]

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -13,6 +13,16 @@ def test_procedure_builds_steps():
     assert proc.steps == {'s1': s1, 's2': s2, 's3': s3}
 
 
+def test_procedure_step_list():
+    s1 = top.ProcedureStep('s1', None, {})
+    s2 = top.ProcedureStep('s2', None, {})
+    s3 = top.ProcedureStep('s3', None, {})
+
+    proc = top.Procedure('p1', [s1, s2, s3])
+
+    assert proc.step_list == [s1, s2, s3]
+
+
 def test_procedure_duplicate_id_errors():
     s1 = top.ProcedureStep('s1', None, {})
     s2 = top.ProcedureStep('s2', None, {})

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -1,0 +1,34 @@
+import pytest
+
+import topside as top
+
+
+def test_procedure_builds_steps():
+    s1 = top.ProcedureStep('s1', None, {})
+    s2 = top.ProcedureStep('s2', None, {})
+    s3 = top.ProcedureStep('s3', None, {})
+
+    proc = top.Procedure('p1', [s1, s2, s3])
+
+    assert proc.steps == {'s1': s1, 's2': s2, 's3': s3}
+
+
+def test_procedure_duplicate_id_errors():
+    s1 = top.ProcedureStep('s1', None, {})
+    s2 = top.ProcedureStep('s2', None, {})
+    s3 = top.ProcedureStep('s1', None, {})
+
+    with pytest.raises(ValueError):
+        top.Procedure('p1', [s1, s2, s3])
+
+
+def test_procedure_index_of():
+    s1 = top.ProcedureStep('s1', None, {})
+    s2 = top.ProcedureStep('s2', None, {})
+    s3 = top.ProcedureStep('s3', None, {})
+
+    proc = top.Procedure('p1', [s1, s2, s3])
+
+    assert proc.index_of('s1') == 0
+    assert proc.index_of('s2') == 1
+    assert proc.index_of('s3') == 2

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -248,7 +248,7 @@ def test_step_advances_time_equally():
 
     assert managed_eng.current_pressures() == unmanaged_eng.current_pressures()
 
-    proc_eng.step(1e6)
+    proc_eng.step_time(1e6)
     unmanaged_eng.step(1e6)
 
     assert managed_eng.current_pressures() == unmanaged_eng.current_pressures()
@@ -266,6 +266,6 @@ def test_step_updates_conditions():
 
     assert proc_eng.ready_to_advance() is False
 
-    proc_eng.step(1e6)
+    proc_eng.step_time(1e6)
 
     assert proc_eng.ready_to_advance() is True


### PR DESCRIPTION
This commit changes the application ProceduresBridge to use a
ProceduresEngine as the source of the procedure rather than a list of
strings. Currently we still use a hardcoded test procedure (as well as a
mock PlumbingEngine), since we don't have any source for procedures
otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/53)
<!-- Reviewable:end -->
