### PR TITLE
proc: Add ProcedureSuite class

### DIFF
--- a/application/procedures_bridge.py
+++ b/application/procedures_bridge.py
@@ -23,8 +23,8 @@ class MockPlumbingEngine:
 def build_test_procedure_suite():
     open_action_1 = top.Action('c1', 'open')
     open_action_2 = top.Action('c2', 'open')
-    close_action_1 = top.Action('c1', 'close')
-    close_action_2 = top.Action('c2', 'close')
+    close_action_1 = top.Action('c1', 'closed')
+    close_action_2 = top.Action('c2', 'closed')
 
     s1 = top.ProcedureStep('s1', open_action_1, [(top.Immediate(), top.Transition('p1', 's2'))])
     s2 = top.ProcedureStep('s2', open_action_2, [(top.Immediate(), top.Transition('p2', 's3'))])
@@ -36,7 +36,7 @@ def build_test_procedure_suite():
 
     p2 = top.Procedure('p2', [s3, s4])
 
-    return [p1, p2]
+    return top.ProcedureSuite([p1, p2], 'p1')
 
 
 class ProcedureStepsModel(QAbstractListModel):
@@ -91,7 +91,7 @@ class ProceduresBridge(QObject):
         plumb = MockPlumbingEngine()
         suite = build_test_procedure_suite()
 
-        self._procedures_engine = top.ProceduresEngine(plumb, suite, 'p1', 's1')
+        self._procedures_engine = top.ProceduresEngine(plumb, suite)
         self._procedure_steps = ProcedureStepsModel(self._procedures_engine.current_procedure())
 
     def _refresh_procedure_view(self):

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -120,3 +120,39 @@ class Procedure:
 
     def __eq__(self, other):
         return self.procedure_id == other.procedure_id and self.step_list == other.step_list
+
+
+class ProcedureSuite:
+    """A set of procedures and associated metadata."""
+
+    def __init__(self, procedures, starting_procedure_id='main'):
+        """
+        Initialize the procedure suite.
+
+        Parameters
+        ----------
+
+        procedures: iterable
+            An iterable of Procedure objects. Each procedure is expected
+            to have a unique procedure ID. Order is irrelevant.
+
+        starting_procedure: str
+            The procedure ID for the starting procedure used when this
+            procedure suite is executed. Defaults to "main" if not
+            specified.
+        """
+        self.starting_procedure_id = starting_procedure_id
+        self.procedures = {}
+
+        for proc in procedures:
+            if proc.procedure_id in self.procedures:
+                raise ValueError(f'duplicate procedure ID {proc.procedure_id} encountered in \
+                                   ProcedureSuite initialization')
+            self.procedures[proc.procedure_id] = proc
+
+    def __eq__(self, other):
+        return self.starting_procedure_id == other.starting_procedure_id and \
+            self.procedures == other.procedures
+
+    def __getitem__(self, key):
+        return self.procedures[key]

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -144,11 +144,19 @@ class ProcedureSuite:
         self.starting_procedure_id = starting_procedure_id
         self.procedures = {}
 
+        # TODO(jacob): Allow invalid procedure suites to be created, but
+        # keep track of the invalid reasons (same way plumbing code
+        # works).
+
         for proc in procedures:
             if proc.procedure_id in self.procedures:
-                raise ValueError(f'duplicate procedure ID {proc.procedure_id} encountered in \
-                                   ProcedureSuite initialization')
+                raise ValueError(f'duplicate procedure ID {proc.procedure_id} encountered in '
+                                 + 'ProcedureSuite initialization')
             self.procedures[proc.procedure_id] = proc
+
+        if self.starting_procedure_id not in self.procedures:
+            raise ValueError(f'starting procedure ID {self.starting_procedure_id} not found in '
+                             + 'procedure dict')
 
     def __eq__(self, other):
         return self.starting_procedure_id == other.starting_procedure_id and \

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -11,7 +11,7 @@ class ProceduresEngine:
     represent transitions between these steps.
     """
 
-    def __init__(self, plumbing_engine=None, suite=None, initial_procedure=None, initial_step=None):
+    def __init__(self, plumbing_engine=None, suite=None):
         """
         Initialize the ProceduresEngine.
 
@@ -21,28 +21,18 @@ class ProceduresEngine:
         plumbing_engine: topside.PlumbingEngine
             The PlumbingEngine that this ProceduresEngine should manage.
 
-        procedure_suite: iterable
-            A procedure suite is any iterable of Procedure objects (but
-            typically a list).
-
-        initial_step: str
-            The initial procedure step that this ProceduresEngine should
-            begin in. Note that the action associated with this step
-            will not be executed (unless the step is eventually reached
-            again); therefore, this step often has a `None` action and
-            a single `Immediate` condition leading directly to the
-            actual "first step" of the procedure.
+        suite: topside.ProcedureSuite
+            The ProcedureSuite that this engine should execute,
+            including information about the starting procedure.
         """
         self._plumb = plumbing_engine
-        self._procedure_suite = None
-        self.current_procedure_id = initial_procedure
+        self._suite = suite
+        self.current_procedure_id = None
         self.current_step = None
 
         if suite is not None:
-            self._procedure_suite = {proc.procedure_id: proc for proc in suite}
-
-        if suite is not None and initial_procedure is not None and initial_step is not None:
-            self.current_step = self._procedure_suite[initial_procedure].steps[initial_step]
+            self.current_procedure_id = self._suite.starting_procedure_id
+            self.current_step = self._suite[self.current_procedure_id].step_list[0]
 
     def execute(self, action):
         """Execute an action on the managed PlumbingEngine."""
@@ -82,7 +72,7 @@ class ProceduresEngine:
             if condition.satisfied():
                 new_proc = transition.procedure
                 self.current_procedure_id = new_proc
-                self.current_step = self._procedure_suite[new_proc].steps[transition.step]
+                self.current_step = self._suite[new_proc].steps[transition.step]
                 self.execute(self.current_step.action)
                 break
 
@@ -106,4 +96,4 @@ class ProceduresEngine:
 
     def current_procedure(self):
         """Return the procedure currently being executed."""
-        return self._procedure_suite[self.current_procedure_id]
+        return self._suite[self.current_procedure_id]

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -85,18 +85,32 @@ def test_procedure_suite_builds_list():
     proc_1 = top.Procedure('p1', [s1, s2])
     proc_2 = top.Procedure('p2', [s1, s3])
 
-    suite = top.ProcedureSuite([proc_1, proc_2])
+    suite = top.ProcedureSuite([proc_1, proc_2], 'p1')
 
     assert suite.procedures == {'p1': proc_1, 'p2': proc_2}
 
 
 def test_procedure_suite_sets_starting_procedure():
-    suite = top.ProcedureSuite([], 'not_main')
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    main = top.Procedure('main', [s1, s2, s3])
+    not_main = top.Procedure('not_main', [s1, s2, s3])
+
+    suite = top.ProcedureSuite([main, not_main], 'not_main')
     assert suite.starting_procedure_id == 'not_main'
 
 
 def test_procedure_suite_defaults_to_main():
-    suite = top.ProcedureSuite([])
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    main = top.Procedure('main', [s1, s2, s3])
+    not_main = top.Procedure('not_main', [s1, s2, s3])
+
+    suite = top.ProcedureSuite([main, not_main])
     assert suite.starting_procedure_id == 'main'
 
 
@@ -110,6 +124,22 @@ def test_procedure_suite_duplicate_name_errors():
 
     with pytest.raises(Exception):
         top.ProcedureSuite([proc_1, proc_2])
+
+
+def test_procedure_suite_no_procedures_errors():
+    with pytest.raises(Exception):
+        top.ProcedureSuite([])
+
+
+def test_procedure_suite_invalid_starting_procedure_errors():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    p1 = top.Procedure('p1', [s1, s2, s3])
+
+    with pytest.raises(Exception):
+        top.ProcedureSuite([p1], 'p2')
 
 
 def test_procedure_suite_equality_equal():
@@ -176,6 +206,6 @@ def test_procedure_suite_indexing():
     proc_1 = top.Procedure('p1', [s1, s2])
     proc_2 = top.Procedure('p2', [s1, s3])
 
-    suite = top.ProcedureSuite([proc_1, proc_2])
+    suite = top.ProcedureSuite([proc_1, proc_2], 'p1')
 
     assert suite['p1'] == proc_1

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -75,3 +75,107 @@ def test_procedure_equality_different_steps():
     proc_2 = top.Procedure('p1', [s1, s3])
 
     assert proc_1 != proc_2
+
+
+def test_procedure_suite_builds_list():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite = top.ProcedureSuite([proc_1, proc_2])
+
+    assert suite.procedures == {'p1': proc_1, 'p2': proc_2}
+
+
+def test_procedure_suite_sets_starting_procedure():
+    suite = top.ProcedureSuite([], 'not_main')
+    assert suite.starting_procedure_id == 'not_main'
+
+
+def test_procedure_suite_defaults_to_main():
+    suite = top.ProcedureSuite([])
+    assert suite.starting_procedure_id == 'main'
+
+
+def test_procedure_suite_duplicate_name_errors():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p1', [s1, s3])
+
+    with pytest.raises(Exception):
+        top.ProcedureSuite([proc_1, proc_2])
+
+
+def test_procedure_suite_equality_equal():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite_1 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+    suite_2 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+
+    assert suite_1 == suite_2
+
+
+def test_procedure_suite_equality_order_irrelevant():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite_1 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+    suite_2 = top.ProcedureSuite([proc_2, proc_1], 'p1')
+
+    assert suite_1 == suite_2
+
+
+def test_procedure_suite_equality_different_starting_procedure():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite_1 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+    suite_2 = top.ProcedureSuite([proc_1, proc_2], 'p2')
+
+    assert suite_1 != suite_2
+
+
+def test_procedure_suite_equality_different_procedures():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite_1 = top.ProcedureSuite([proc_1], 'p1')
+    suite_2 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+
+    assert suite_1 != suite_2
+
+
+def test_procedure_suite_indexing():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite = top.ProcedureSuite([proc_1, proc_2])
+
+    assert suite['p1'] == proc_1

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -44,7 +44,7 @@ def single_procedure_suite():
 
     proc = top.Procedure('p1', [s1, s2, s3])
 
-    return [proc]
+    return top.ProcedureSuite([proc], 'p1')
 
 
 def branching_procedure_suite_no_options():
@@ -59,7 +59,7 @@ def branching_procedure_suite_no_options():
     proc_1 = top.Procedure('p1', [s1, s2, s3])
     proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return [proc_1, proc_2]
+    return top.ProcedureSuite([proc_1, proc_2], 'p1')
 
 
 def branching_procedure_suite_one_option():
@@ -74,7 +74,7 @@ def branching_procedure_suite_one_option():
     proc_1 = top.Procedure('p1', [s1, s2, s3])
     proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return [proc_1, proc_2]
+    return top.ProcedureSuite([proc_1, proc_2], 'p1')
 
 
 def branching_procedure_suite_two_options():
@@ -89,7 +89,7 @@ def branching_procedure_suite_two_options():
     proc_1 = top.Procedure('p1', [s1, s2, s3])
     proc_2 = top.Procedure('p2', [s1, s2, s3])
 
-    return [proc_1, proc_2]
+    return top.ProcedureSuite([proc_1, proc_2], 'p1')
 
 
 def test_execute_custom_action():
@@ -104,26 +104,26 @@ def test_execute_custom_action():
 
 
 def test_ready_to_advance_if_condition_satisfied():
-    proc_eng = top.ProceduresEngine(None, single_procedure_suite(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(None, single_procedure_suite())
 
     assert proc_eng.ready_to_advance() is True
 
 
 def test_ready_to_advance_one_is_enough():
-    proc_eng = top.ProceduresEngine(None, branching_procedure_suite_one_option(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(None, branching_procedure_suite_one_option())
 
     assert proc_eng.ready_to_advance() is True
 
 
 def test_ready_to_advance_no_options():
-    proc_eng = top.ProceduresEngine(None, branching_procedure_suite_no_options(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(None, branching_procedure_suite_no_options())
 
     assert proc_eng.ready_to_advance() is False
 
 
 def test_next_step_immediate():
     plumb_eng = one_component_engine()
-    proc_eng = top.ProceduresEngine(plumb_eng, single_procedure_suite(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, single_procedure_suite())
 
     assert proc_eng.current_step.step_id == 's1'
     assert plumb_eng.current_state('c1') == 'closed'
@@ -137,7 +137,7 @@ def test_next_step_immediate():
 
 def test_next_step_requires_satisfaction():
     plumb_eng = one_component_engine()
-    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_no_options(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_no_options())
 
     assert proc_eng.current_procedure_id == 'p1'
     assert proc_eng.current_step.step_id == 's1'
@@ -150,7 +150,7 @@ def test_next_step_requires_satisfaction():
 
 def test_next_step_follows_satisfied_condition():
     plumb_eng = one_component_engine()
-    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_one_option(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_one_option())
 
     assert proc_eng.current_procedure_id == 'p1'
     assert proc_eng.current_step.step_id == 's1'
@@ -163,7 +163,7 @@ def test_next_step_follows_satisfied_condition():
 
 def test_next_step_follows_highest_priority_condition():
     plumb_eng = one_component_engine()
-    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_two_options(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, branching_procedure_suite_two_options())
 
     assert proc_eng.current_procedure_id == 'p1'
     assert proc_eng.current_step.step_id == 's1'
@@ -186,9 +186,9 @@ def test_transitions_respects_procedure_identifier():
 
     proc_1 = top.Procedure('p1', [s1, same_name_1])
     proc_2 = top.Procedure('p2', [same_name_2])
-    proc_suite = [proc_1, proc_2]
+    proc_suite = top.ProcedureSuite([proc_1, proc_2], 'p1')
 
-    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
 
     assert proc_eng.current_procedure_id == 'p1'
     assert proc_eng.current_step.step_id == 's1'
@@ -203,9 +203,9 @@ def test_update_conditions_updates_pressures():
 
     s1 = top.ProcedureStep('s1', None, [(top.Less(1, 75), top.Transition('p1', 's2'))])
     proc = top.Procedure('p1', [s1])
-    proc_suite = [proc]
+    proc_suite = top.ProcedureSuite([proc], 'p1')
 
-    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
 
     assert proc_eng.ready_to_advance() is False
 
@@ -221,9 +221,9 @@ def test_update_conditions_updates_time():
 
     s1 = top.ProcedureStep('s1', None, [(top.WaitUntil(1e6), 's2')])
     proc = top.Procedure('p1', [s1])
-    proc_suite = [proc]
+    proc_suite = top.ProcedureSuite([proc], 'p1')
 
-    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
 
     assert proc_eng.ready_to_advance() is False
 
@@ -244,7 +244,7 @@ def test_step_advances_time_equally():
 
     unmanaged_eng = copy.deepcopy(managed_eng)
 
-    proc_eng = top.ProceduresEngine(managed_eng, single_procedure_suite(), 'p1', 's1')
+    proc_eng = top.ProceduresEngine(managed_eng, single_procedure_suite())
 
     assert managed_eng.current_pressures() == unmanaged_eng.current_pressures()
 
@@ -260,9 +260,9 @@ def test_step_updates_conditions():
 
     s1 = top.ProcedureStep('s1', None, [(top.Less(1, 75), 's2')])
     proc = top.Procedure('p1', [s1])
-    proc_suite = [proc]
+    proc_suite = top.ProcedureSuite([proc], 'p1')
 
-    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite, 'p1', 's1')
+    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
 
     assert proc_eng.ready_to_advance() is False
 


### PR DESCRIPTION
New class that provides a convenient way for grouping a set of related
procedures and associated metadata. Currently the only metadata is the
entry point into the suite (the first procedure that should be
executed), but we also add checks for duplicate procedure IDs, fixing a
potential bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/56)
<!-- Reviewable:end -->
