### PR TITLE
proc: Fix a few bugs in procedure equality

### DIFF
--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -119,7 +119,9 @@ class Procedure:
         return self.step_id_to_idx[step_id]
 
     def __eq__(self, other):
-        return self.procedure_id == other.procedure_id and self.step_list == other.step_list
+        return type(self) == type(other) and \
+            self.procedure_id == other.procedure_id and \
+            self.step_list == other.step_list
 
 
 class ProcedureSuite:
@@ -159,7 +161,8 @@ class ProcedureSuite:
                              + 'procedure dict')
 
     def __eq__(self, other):
-        return self.starting_procedure_id == other.starting_procedure_id and \
+        return type(self) == type(other) and \
+            self.starting_procedure_id == other.starting_procedure_id and \
             self.procedures == other.procedures
 
     def __getitem__(self, key):

--- a/topside/procedures/tests/test_conditions.py
+++ b/topside/procedures/tests/test_conditions.py
@@ -13,6 +13,14 @@ def test_immediate_condition():
     assert cond.satisfied() is True
 
 
+def test_immediate_equality():
+    cond1 = top.Immediate()
+    cond2 = top.Immediate()
+
+    assert cond1 == cond2
+    assert cond1 != None
+
+
 def test_wait_until_condition_exact():
     cond = top.WaitUntil(100)
     state = {'time': 100}
@@ -40,26 +48,16 @@ def test_wait_until_condition_after():
     assert cond.satisfied() is True
 
 
-def test_custom_comparison_condition_requires_cond_fn():
-    cond = top.Comparison('A1', 100)
-    state = {'pressures': {'A1': 100}}
-    cond.update(state)
+def test_wait_until_equality():
+    cond1 = top.WaitUntil(100)
+    cond2 = top.WaitUntil(100)
+    cond3 = top.WaitUntil(200)
 
-    with pytest.raises(NotImplementedError):
-        cond.satisfied()
+    assert cond1 == cond2
+    assert cond1 != cond3
 
-
-def test_custom_comparison_condition():
-    cond = top.Comparison('A1', 100, lambda x, y: abs(x - y) > 10)
-    assert cond.satisfied() is False
-
-    state1 = {'pressures': {'A1': 100}}
-    cond.update(state1)
-    assert cond.satisfied() is False
-
-    state2 = {'pressures': {'A1': 111}}
-    cond.update(state2)
-    assert cond.satisfied() is True
+    assert cond1 != 100
+    assert cond1 != None
 
 
 def test_equal_condition_equal():
@@ -87,6 +85,24 @@ def test_equal_condition_with_eps():
     assert cond.satisfied() is False
     cond.update(state)
     assert cond.satisfied() is True
+
+
+def test_equal_condition_equality():
+    cond1 = top.Equal('p1', 100)
+    cond2 = top.Equal('p1', 100)
+    cond3 = top.Equal('p1', 100, 0)
+    cond4 = top.Equal('p1', 200)
+    cond5 = top.Equal('p2', 100)
+    cond6 = top.Equal('p1', 100, 10)
+
+    assert cond1 == cond2
+    assert cond1 == cond3
+    assert cond1 != cond4
+    assert cond1 != cond5
+    assert cond1 != cond6
+
+    assert cond1 != 100
+    assert cond1 != None
 
 
 def test_less_condition_equal():
@@ -197,6 +213,19 @@ def test_greater_equal_condition_less():
     assert cond.satisfied() is False
 
 
+def test_comparison_equality():
+    c1 = top.Less('a1', 100)
+    c2 = top.Less('a1', 100)  # same
+    c3 = top.Less('b2', 100)  # different node
+    c4 = top.Less('a1', 200)  # different reference
+    c5 = top.Greater('a1', 100)  # different type
+
+    assert c1 == c2
+    assert c1 != c3
+    assert c1 != c4
+    assert c1 != c5
+
+
 def test_and_one_condition():
     and_sat = top.And([top.Immediate()])
     and_unsat = top.And([NeverSatisfied()])
@@ -240,6 +269,18 @@ def test_and_requires_all_satisfied():
     assert eq_cond_1.satisfied() is True
     assert eq_cond_2.satisfied() is False
     assert and_cond.satisfied() is False
+
+
+def test_and_equality():
+    and_1 = top.And([top.Immediate(), top.Immediate()])
+    and_2 = top.And([top.Immediate(), top.Immediate()])
+    and_3 = top.And([NeverSatisfied(), top.Immediate()])
+
+    assert and_1 == and_2
+    assert and_1 != and_3
+
+    assert and_1 != 10
+    assert and_1 != None
 
 
 def test_or_one_condition():
@@ -287,6 +328,18 @@ def test_or_requires_only_one_satisfied():
     assert or_cond.satisfied() is True
 
 
+def test_or_equality():
+    or_1 = top.Or([top.Immediate(), top.Immediate()])
+    or_2 = top.Or([top.Immediate(), top.Immediate()])
+    or_3 = top.Or([NeverSatisfied(), top.Immediate()])
+
+    assert or_1 == or_2
+    assert or_1 != or_3
+
+    assert or_1 != 10
+    assert or_1 != None
+
+
 def test_nested_logic_works():
     eq_cond_1 = top.Equal('A1', 100)
     eq_cond_2 = top.Equal('A2', 100)
@@ -307,3 +360,10 @@ def test_nested_logic_works():
     assert eq_cond_3.satisfied() is False
     assert or_cond_1.satisfied() is True
     assert or_cond_2.satisfied() is True
+
+
+def test_and_or_not_equal():
+    and_cond = top.And([NeverSatisfied(), top.Immediate()])
+    or_cond = top.Or([NeverSatisfied(), top.Immediate()])
+
+    assert and_cond != or_cond

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -44,6 +44,18 @@ def test_procedure_index_of():
     assert proc.index_of('s3') == 2
 
 
+def test_procedure_equality_different_type():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2, s3])
+
+    assert proc_1 != 'proc_1'
+    assert proc_1 != 10
+    assert proc_1 != None
+
+
 def test_procedure_equality_equal():
     s1 = top.ProcedureStep('s1', None, [])
     s2 = top.ProcedureStep('s2', None, [])
@@ -140,6 +152,21 @@ def test_procedure_suite_invalid_starting_procedure_errors():
 
     with pytest.raises(Exception):
         top.ProcedureSuite([p1], 'p2')
+
+
+def test_procedure_suite_equality_different_type():
+    s1 = top.ProcedureStep('s1', None, [])
+    s2 = top.ProcedureStep('s2', None, [])
+    s3 = top.ProcedureStep('s3', None, [])
+
+    proc_1 = top.Procedure('p1', [s1, s2])
+    proc_2 = top.Procedure('p2', [s1, s3])
+
+    suite_1 = top.ProcedureSuite([proc_1, proc_2], 'p1')
+
+    assert suite_1 != 'suite_1'
+    assert suite_1 != 10
+    assert suite_1 != None
 
 
 def test_procedure_suite_equality_equal():


### PR DESCRIPTION
Should have added more unit tests the first time around!

Fix the following bugs:
- Equality comparisons were not checking the type of `other`, except for
in the Comparison class. This meant that comparing a Procedure to `None`
would just error, and comparing an And to an Or with the same
subconditions would be `True`!
- Comparison base class instances with custom comparison functions would
always compare equal, regardless of what the custom function is.
Unfortunately, there isn't a trivial way to check whether two lambdas
are equal to each other. For now, I've just removed the custom comp_fn
functionality, since we don't use it anywhere anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/59)
<!-- Reviewable:end -->
