### PR TITLE
proc: Add logical expressions in comparisons

### DIFF
--- a/topside/procedures/tests/test_conditions.py
+++ b/topside/procedures/tests/test_conditions.py
@@ -242,6 +242,14 @@ def test_and_two_conditions():
     assert and_unsat.satisfied() is False
 
 
+def test_nested_and_conditions():
+    and_sat = top.And([top.Immediate(), top.And([top.Immediate(), top.Immediate()])])
+    and_unsat = top.And([top.Immediate(), top.And([NeverSatisfied(), top.Immediate()])])
+
+    assert and_sat.satisfied() is True
+    assert and_unsat.satisfied() is False
+
+
 def test_and_updates_subconditions():
     eq_cond = top.Equal('A1', 100)
     and_cond = top.And([eq_cond])
@@ -294,6 +302,14 @@ def test_or_one_condition():
 def test_or_two_conditions():
     or_sat = top.Or([top.Immediate(), NeverSatisfied()])
     or_unsat = top.Or([NeverSatisfied(), NeverSatisfied()])
+
+    assert or_sat.satisfied() is True
+    assert or_unsat.satisfied() is False
+
+
+def test_nested_or_conditions():
+    or_sat = top.Or([NeverSatisfied(), top.Or([top.Immediate(), NeverSatisfied()])])
+    or_unsat = top.Or([NeverSatisfied(), top.Or([NeverSatisfied(), NeverSatisfied()])])
 
     assert or_sat.satisfied() is True
     assert or_unsat.satisfied() is False

--- a/topside/procedures/tests/test_proclang.py
+++ b/topside/procedures/tests/test_proclang.py
@@ -270,3 +270,79 @@ def test_parse_from_file():
     ])
 
     assert suite == expected_suite
+
+def test_parse_steps_with_complex_comparisons():
+    proclang = '''
+    main:
+        1. set injector_valve to open
+        2. [p1 < 100 and p2 > 200] set vent_valve to closed
+        3. [p1 > 100 or  p2 < 200] set vent_valve to open
+        4. [(p1 <= 100)] set vent_valve to closed
+        5. [p1 < 100 or p2 > 200 and p3 < 100] set vent_valve to open
+        6. [p1 < 100 and p2 > 200 or p3 < 100] set vent_valve to open
+        7. [(p1 < 100 or p2 > 200) and p3 < 100] set vent_valve to closed
+    '''
+    suite = top.proclang.parse(proclang)
+
+    compAnd = top.And([top.Less('p1', 100), top.Greater('p2', 200)])
+    compOr  = top.Or([top.Greater('p1', 100), top.Less('p2', 200)])
+    compAndOr1 = top.Or([top.Less('p1', 100), top.And([top.Greater('p2', 200), top.Less('p3', 100)])])
+    compAndOr2 = top.Or([top.And([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
+    compAndOr3 = top.And([top.Or([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
+
+    expected_suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.Action('injector_valve', 'open'), [
+                (compAnd, top.Transition('main', '2'))
+            ]),
+            top.ProcedureStep('2', top.Action('vent_valve', 'closed'), [
+                (compOr, top.Transition('main', '3'))
+            ]),
+            top.ProcedureStep('3', top.Action('vent_valve', 'open'), [
+                (top.LessEqual('p1', 100), top.Transition('main', '4'))
+            ]),
+            top.ProcedureStep('4', top.Action('vent_valve', 'closed'), [
+                (compAndOr1, top.Transition('main', '5'))
+            ]),
+            top.ProcedureStep('5', top.Action('vent_valve', 'open'), [
+                (compAndOr2, top.Transition('main', '6'))
+            ]),
+            top.ProcedureStep('6', top.Action('vent_valve', 'open'), [
+                (compAndOr3, top.Transition('main', '7'))
+            ]),
+            top.ProcedureStep('7', top.Action('vent_valve', 'closed'), [])
+        ])
+    ])
+
+    assert suite == expected_suite
+
+def test_parse_steps_with_multiple_comparisons():
+    proclang = '''
+    main:
+        1. set injector_valve to open
+        2. [p1 < 100 and p2 < 100 and p3 < 100] set vent_valve to closed
+        3. [p1 < 100 or  p2 < 100 or  p3 < 100] set vent_valve to open
+        4. [p1 < 100 and p2 < 100 and p3 < 100 or p1 < 100 and p2 < 100] set vent_valve to open
+    '''
+    suite = top.proclang.parse(proclang)
+
+    p1 = top.Less('p1', 100)
+    p2 = top.Less('p2', 100)
+    p3 = top.Less('p3', 100)
+
+    expected_suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.Action('injector_valve', 'open'), [
+                (top.And([p1, p2, p3]), top.Transition('main', '2'))
+            ]),
+            top.ProcedureStep('2', top.Action('vent_valve', 'closed'), [
+                (top.Or([p1, p2, p3]), top.Transition('main', '3'))
+            ]),
+            top.ProcedureStep('3', top.Action('vent_valve', 'open'), [
+                (top.Or([top.And([p1, p2, p3]), top.And([p1, p2])]), top.Transition('main', '4'))
+            ]),
+            top.ProcedureStep('4', top.Action('vent_valve', 'open'), [])
+        ])
+    ])
+
+    assert suite == expected_suite

--- a/topside/procedures/tests/test_proclang.py
+++ b/topside/procedures/tests/test_proclang.py
@@ -284,31 +284,31 @@ def test_parse_steps_with_complex_comparisons():
     '''
     suite = top.proclang.parse(proclang)
 
-    compAnd = top.And([top.Less('p1', 100), top.Greater('p2', 200)])
-    compOr  = top.Or([top.Greater('p1', 100), top.Less('p2', 200)])
-    compAndOr1 = top.Or([top.Less('p1', 100), top.And([top.Greater('p2', 200), top.Less('p3', 100)])])
-    compAndOr2 = top.Or([top.And([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
-    compAndOr3 = top.And([top.Or([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
+    comp_and = top.And([top.Less('p1', 100), top.Greater('p2', 200)])
+    comp_or  = top.Or([top.Greater('p1', 100), top.Less('p2', 200)])
+    comp_and_or_1 = top.Or([top.Less('p1', 100), top.And([top.Greater('p2', 200), top.Less('p3', 100)])])
+    comp_and_or_2 = top.Or([top.And([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
+    comp_and_or_3 = top.And([top.Or([top.Less('p1', 100), top.Greater('p2', 200)]), top.Less('p3', 100)])
 
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.Action('injector_valve', 'open'), [
-                (compAnd, top.Transition('main', '2'))
+                (comp_and, top.Transition('main', '2'))
             ]),
             top.ProcedureStep('2', top.Action('vent_valve', 'closed'), [
-                (compOr, top.Transition('main', '3'))
+                (comp_or, top.Transition('main', '3'))
             ]),
             top.ProcedureStep('3', top.Action('vent_valve', 'open'), [
                 (top.LessEqual('p1', 100), top.Transition('main', '4'))
             ]),
             top.ProcedureStep('4', top.Action('vent_valve', 'closed'), [
-                (compAndOr1, top.Transition('main', '5'))
+                (comp_and_or_1, top.Transition('main', '5'))
             ]),
             top.ProcedureStep('5', top.Action('vent_valve', 'open'), [
-                (compAndOr2, top.Transition('main', '6'))
+                (comp_and_or_2, top.Transition('main', '6'))
             ]),
             top.ProcedureStep('6', top.Action('vent_valve', 'open'), [
-                (compAndOr3, top.Transition('main', '7'))
+                (comp_and_or_3, top.Transition('main', '7'))
             ]),
             top.ProcedureStep('7', top.Action('vent_valve', 'closed'), [])
         ])
@@ -360,28 +360,28 @@ def test_parse_logical_operator_forms():
     '''
     suite = top.proclang.parse(proclang)
 
-    compAnd = top.And([top.Less('p1', 100), top.Less('p2', 100)])
-    compOr = top.Or([top.Less('p1', 100), top.Less('p2', 100)])
+    comp_and = top.And([top.Less('p1', 100), top.Less('p2', 100)])
+    comp_or = top.Or([top.Less('p1', 100), top.Less('p2', 100)])
 
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.Action('injector_valve', 'open'), [
-                (compAnd, top.Transition('main', '2'))
+                (comp_and, top.Transition('main', '2'))
             ]),
             top.ProcedureStep('2', top.Action('vent_valve', 'open'), [
-                (compAnd, top.Transition('main', '3'))
+                (comp_and, top.Transition('main', '3'))
             ]),
             top.ProcedureStep('3', top.Action('vent_valve', 'open'), [
-                (compAnd, top.Transition('main', '4'))
+                (comp_and, top.Transition('main', '4'))
             ]),
             top.ProcedureStep('4', top.Action('vent_valve', 'open'), [
-                (compOr, top.Transition('main', '5'))
+                (comp_or, top.Transition('main', '5'))
             ]),
             top.ProcedureStep('5', top.Action('vent_valve', 'open'), [
-                (compOr, top.Transition('main', '6'))
+                (comp_or, top.Transition('main', '6'))
             ]),
             top.ProcedureStep('6', top.Action('vent_valve', 'open'), [
-                (compOr, top.Transition('main', '7'))
+                (comp_or, top.Transition('main', '7'))
             ]),
             top.ProcedureStep('7', top.Action('vent_valve', 'open'), [])
         ])
@@ -397,10 +397,12 @@ def test_parse_combined_conditions():
     '''
 
     suite = top.proclang.parse(proclang)
+
+    comp_or = top.Or([top.Less('p1', 100), top.And([top.WaitUntil(1e6*500), top.Less('p2', 200)])])
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.Action('s', 'v'), [
-                (top.Or([top.Less('p1', 100), top.And([top.WaitUntil(1e6*500), top.Less('p2', 200)])]), top.Transition('main', '2'))
+                (comp_or, top.Transition('main', '2'))
             ]),
             top.ProcedureStep('2', top.Action('s', 'v'), [])
         ])


### PR DESCRIPTION
So far this supports and, or, and parentheses. And is taken as having
higher precedence, so "x and y or z" is parsed as "(x and y) or z".

There are three terminal symbols for and and or symbols, "AND, "and",
and "&&". I'm not sure if that's the desired behaviour.

Addresses #61

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/66)
<!-- Reviewable:end -->
