### PR TITLE
Add latex export class function

### DIFF
--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -22,6 +22,17 @@ class Action:
     component: str
     state: str
 
+    def export(self, fmt):
+        if fmt == "latex":
+            if self.state == "open":
+                return "Open " + self.component
+            elif self.state == "closed":
+                return "Close " + self.component
+            else:
+                return "Set " + self.component + " to " + self.state
+        else:
+            raise NotImplementedError("")
+
 
 @dataclass
 class Transition:
@@ -71,6 +82,12 @@ class ProcedureStep:
     action: Action
     conditions: list
     operator: str
+
+    def export(self, fmt):
+        if fmt == "latex":
+            return self.action.export(fmt)
+        else:
+            raise NotImplementedError("")
 
 
 class Procedure:
@@ -127,6 +144,18 @@ class Procedure:
             self.procedure_id == other.procedure_id and \
             self.step_list == other.step_list
 
+    def export(self, fmt):
+        if fmt == "latex":
+            export_val = f"\\subsection{{{self.procedure_id}}}"
+            if len(self.step_list) > 0:
+                export_val += "\n\\begin{checklist}"
+                for i in self.step_list:
+                    export_val += "\n    \\item " + i.export(fmt)
+                export_val += "\n\\end{checklist}"
+            return export_val
+        else:
+            raise NotImplementedError("")
+
 
 class ProcedureSuite:
     """A set of procedures and associated metadata."""
@@ -171,3 +200,9 @@ class ProcedureSuite:
 
     def __getitem__(self, key):
         return self.procedures[key]
+
+    def export(self, fmt="ProcLang"):
+        if fmt == "ProcLang":
+            return "\n".join([self.procedures[proc].export(fmt) for proc in self.procedures])
+        else:
+            raise NotImplementedError(f"Format \"{fmt}\" not supported")

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -1,0 +1,21 @@
+import pytest
+import topside as top
+
+
+def test_procedure_latex_export():
+    s1 = top.ProcedureStep('s1', top.Action("remote fill valve", "open"), [])
+    s2 = top.ProcedureStep('s2', top.Action("remote vent valve", "closed"), [])
+
+    proc = top.Procedure('p1', [s1, s2])
+
+    export = proc.export("latex")
+
+    print(export)
+
+    expected_export = r"""\subsection{p1}
+\begin{checklist}
+    \item Open remote fill valve
+    \item Close remote vent valve
+\end{checklist}"""
+    print(expected_export)
+    assert export == expected_export


### PR DESCRIPTION
Pull request isn't (currently) intended to be merged to master, just want to demo my idea for latex export: every class generated on parse gets an `export(format)` function added to it, and the higher level classes call lower level ones to generate the full latex file.

Eventually we could add more export formats, eg a proc_lang exporter to address issue #62.

Please lemme know your thoughts on this approach, or whether other options (external classes that know the internal structure of the procedure suite classes, or a different Lark transformer to go straight from proclang to latex) should be tried out instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/73)
<!-- Reviewable:end -->
