### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.github/workflows/build_pyinstaller.yml
+++ b/.github/workflows/build_pyinstaller.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Cache pip dependencies
       id: cache

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # Python
 
-venv/
+[.]venv/
 
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Waterloo Rocketry's operations simulator is a tool for modelling and simulating 
 
 #### Requirements
 
-If you just want to use or develop the Topside core libraries, Python 3.7 or newer is required. If you want to build a standalone application, currently _only_ Python 3.7 releases are supported, as PyInstaller requires <=3.7 and dataclasses require >=3.7.
+Python 3.7 or newer is required.
 
 Required Python packages can be installed using `pip install -r requirements.txt`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,23 @@
-autopep8==1.5.2
+autopep8==1.5.4
 cx-freeze==6.1
 datatest==0.9.6
-lark-parser==0.9.0
-matplotlib==3.2.0
+lark-parser==0.10.0
+
+# NOTE(jacob): Matplotlib 3.3.0 does not work with PyInstaller, see
+# github.com/pyinstaller/pyinstaller/issues/5004
+matplotlib==3.2.2
+
 networkx==2.4
-numpy==1.15.1
-pyinstaller==4.0
+numpy==1.19.2
 PySide2==5.14.1
 pytest==5.4.2
 pyyaml==5.3.1
-scipy==1.4.1
+scipy==1.5.2
 setuptools==41.2.0
 shiboken2==5.14.1
 twine==3.1.1
 wheel==0.34.2
+
+# TODO(jacob): Install PyInstaller from PyPI rather than GitHub once a
+# new release is cut.
+https://codeload.github.com/pyinstaller/pyinstaller/tar.gz/81d7e6a761fada855eb9a4b7e29a12c1da8a6075


### PR DESCRIPTION
PyInstaller now supports Python 3.8 at HEAD, so we can start using it as
our development version! There isn't yet an official PyPI release for
PyInstaller 4.1, so for now we fetch the package from GitHub.

Also upgraded a few other dependencies to versions with binary wheels
for 3.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/75)
<!-- Reviewable:end -->
