### PR TITLE
pdl: Fix a bug in typedef validation

### DIFF
--- a/topside/pdl/example.yaml
+++ b/topside/pdl/example.yaml
@@ -15,6 +15,18 @@ body:
       closed:
         edge_name: closed_teq
 
+- typedef:
+    params: [teq_1, teq_2]
+    name: two_setting_valve
+    edges:
+      edge1:
+        nodes: [0, 1]
+    states:
+      position_1:
+        edge1: teq_1
+      position_2:
+        edge1: teq_2
+
 - component:
     name: fill_valve
     edges:

--- a/topside/pdl/file.py
+++ b/topside/pdl/file.py
@@ -136,7 +136,7 @@ class File:
 
         # TODO(wendi): support default arguments
         params = self.typedefs[def_type]['params']
-        if len(params) != len(entry):
+        if len(params) != len(entry['params']):
             raise exceptions.BadInputError(f"not all params ({params}) present in component "
                                            "declaration")
 

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -11,7 +11,7 @@ def test_valid_pdl():
     assert file.namespace == 'example'
     assert file.imports == ['stdlib']
 
-    assert len(file.typedefs) == 1
+    assert len(file.typedefs) == 2
     assert len(file.components) == 6
     assert len(file.graphs) == 2
 
@@ -101,7 +101,7 @@ body:
         _ = top.File(no_state_no_teq, input_type='s')
 
 
-def test_invalide_param_missing():
+def test_invalid_param_missing():
     param_missing =\
         """
 name: example

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -18,7 +18,7 @@ def test_package_storage():
     assert len(pack.component_dict['stdlib']) == 0
     assert len(pack.components()) == 6
 
-    assert len(pack.typedefs[namespace]) == 1
+    assert len(pack.typedefs[namespace]) == 2
     assert len(pack.typedefs['stdlib']) == 1
 
     assert len(pack.graph_dict[namespace]) == 2
@@ -69,7 +69,7 @@ def test_files_unchanged():
 
     top.Package([file])
 
-    assert len(file.typedefs) == 1
+    assert len(file.typedefs) == 2
     assert len(file.components) == 6
     assert len(file.graphs) == 2
 


### PR DESCRIPTION
Typedef validation in `File` was comparing two values that are not, in
general, expected to be equal: the number of typedef parameters
(variable) and the number of fields in a typedef entry (at least 3).
Unit tests didn't catch this because these numbers happened to be equal
for all of the examples. Fixed the comparison and added a typedef with 2
parameters to the example PDL file, which caused the existing tests to
fail before the fix.

Will wait for #72 so that I don't cause merge conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/77)
<!-- Reviewable:end -->
