### PR TITLE
Allow parser to take paths, not files

### DIFF
--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -9,7 +9,7 @@ class Parser:
 
     def __init__(self, files, input_type='f'):
         """
-        Initialize a parser from one or more pdl files.
+        Initialize a parser from one or more PDL files.
 
         A Parser contains a Package; most of its functionality lies in restructuring the data
         contained in its Package into output suitable for loading a plumbing engine.
@@ -18,9 +18,9 @@ class Parser:
         ----------
 
         files: iterable
-            files is the iterable (usually a list) of one or more paths of the pdl files we
+            files is the iterable (usually a list) of one or more paths of the PDL files we
             want parsed. Alternatively, it can also be a list of strings that are each a valid
-            pdl file.
+            PDL file.
 
         input_type: char
             input_type indicates whether the argument provided to "files" is

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -9,7 +9,7 @@ class Parser:
 
     def __init__(self, files, input_type='f'):
         """
-        Initialize a parser from one or more Files.
+        Initialize a parser from one or more pdl files.
 
         A Parser contains a Package; most of its functionality lies in restructuring the data
         contained in its Package into output suitable for loading a plumbing engine.

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -7,7 +7,7 @@ import topside.pdl.exceptions as exceptions
 class Parser:
     """Produces plumbing engine input that's representative of its given files."""
 
-    def __init__(self, files):
+    def __init__(self, files, input_type='f'):
         """
         Initialize a parser from one or more Files.
 
@@ -18,10 +18,19 @@ class Parser:
         ----------
 
         files: iterable
-            files is the iterable (usually a list) of one or more Files whose contents should go
-            into the Parser.
+            files is the iterable (usually a list) of one or more paths of the pdl files we
+            want parsed. Alternatively, it can also be a list of strings that are each a valid
+            pdl file.
+
+        input_type: char
+            input_type indicates whether the argument provided to "files" is
+            a list of file paths (f) or a list of strings (s).
+
         """
-        self.package = top.Package(files)
+        file_list = []
+        for file in files:
+            file_list.append(top.File(file, input_type))
+        self.package = top.Package(file_list)
 
         self.components = {}
         self.mapping = {}

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -6,9 +6,8 @@ import topside.pdl.utils as utils
 
 
 def test_valid_file():
-    file = top.File(utils.example_path)
 
-    parsed = top.Parser([file])
+    parsed = top.Parser([utils.example_path])
 
     assert len(parsed.components) == 6
     for component in parsed.components.values():
@@ -108,9 +107,8 @@ body:
     states:
         fill_valve: open
 """
-    no_main_file = top.File(no_main_graph, 's')
     with pytest.raises(exceptions.BadInputError):
-        top.Parser([no_main_file])
+        top.Parser([no_main_graph], 's')
 
 
 def test_invalid_component():
@@ -144,9 +142,8 @@ body:
       fill_valve: open
     """
 
-    teq_low_file = top.File(teq_too_low, 's')
     # this shouldn't raise an error, invalid components are legal
-    parse = top.Parser([teq_low_file])
+    parse = top.Parser([teq_too_low], 's')
 
     plumb = parse.make_engine()
     assert not plumb.is_valid()


### PR DESCRIPTION
This allows the parser to take a list of paths/strings containing valid PDL, rather than requiring that a list of files be passed in. The api for specifying whether you're putting in paths or pdl is the same as with `Files` - the optional `input_type` parameter can be set to `'s'` to indicate we're inputting strings, otherwise it defaults to `f` (file paths). 

Might cause merge conflicts with #79, can rebase this onto that and add it to the daisy chain of PRs, or we could make this PR yet another dependency for #79 to be merged?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/83)
<!-- Reviewable:end -->
