### PR TITLE
Latex export

### DIFF
--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -58,6 +58,12 @@ class And:
     def __eq__(self, other):
         return type(self) == type(other) and self._conditions == other._conditions
 
+    def export(self, fmt):
+        if fmt == 'latex':
+            return ' and '.join([cond.export(fmt) for cond in self._conditions])
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+
 
 class Or:
     """
@@ -103,6 +109,12 @@ class Or:
 
     def __eq__(self, other):
         return type(self) == type(other) and self._conditions == other._conditions
+
+    def export(self, fmt):
+        if fmt == 'latex':
+            return ' or '.join([cond.export(fmt) for cond in self._conditions])
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
 
 
 class WaitUntil:
@@ -254,6 +266,12 @@ class Equal(Comparison):
             self.reference_pressure == other.reference_pressure and \
             self.eps == other.eps
 
+    def export(self, fmt):
+        if fmt == 'latex':
+            return self.node + " is equal to " + str(round(self.reference_pressure)) + "psi"
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+
 
 class Less(Comparison):
     """Condition that tests if a pressure is less than a reference."""
@@ -290,6 +308,12 @@ class LessEqual(Comparison):
         """Compare pressures using less-than-or-equal."""
         return current_pressure <= reference_pressure
 
+    def export(self, fmt):
+        if fmt == 'latex':
+            return self.node + " is less than or equal to " + str(round(self.reference_pressure)) + "psi"
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+
 
 class GreaterEqual(Comparison):
     """Condition that tests if a pressure is greater than or equal to a reference."""
@@ -297,3 +321,9 @@ class GreaterEqual(Comparison):
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using greater-than-or-equal."""
         return current_pressure >= reference_pressure
+
+    def export(self, fmt):
+        if fmt == 'latex':
+            return self.node + " is greater than or equal to " + str(round(self.reference_pressure)) + "psi"
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')

--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -1,3 +1,6 @@
+import topside as top
+
+
 class Immediate:
     """Condition that is always satisfied."""
 
@@ -59,10 +62,10 @@ class And:
         return type(self) == type(other) and self._conditions == other._conditions
 
     def export(self, fmt):
-        if fmt == 'latex':
+        if fmt == top.ExportFormat.Latex:
             return ' and '.join([cond.export(fmt) for cond in self._conditions])
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class Or:
@@ -111,10 +114,10 @@ class Or:
         return type(self) == type(other) and self._conditions == other._conditions
 
     def export(self, fmt):
-        if fmt == 'latex':
+        if fmt == top.ExportFormat.Latex:
             return ' or '.join([cond.export(fmt) for cond in self._conditions])
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class WaitUntil:
@@ -160,10 +163,10 @@ class WaitUntil:
         return type(self) == type(other) and self.target_t == other.target_t
 
     def export(self, fmt):
-        if fmt == 'latex':
+        if fmt == top.ExportFormat.Latex:
             return f'{round(self.target_t / 1e6)} seconds'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class Comparison:
@@ -267,10 +270,10 @@ class Equal(Comparison):
             self.eps == other.eps
 
     def export(self, fmt):
-        if fmt == 'latex':
-            return self.node + " is equal to " + str(round(self.reference_pressure)) + "psi"
+        if fmt == top.ExportFormat.Latex:
+            return f'{self.node} is equal to {round(self.reference_pressure)}psi'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class Less(Comparison):
@@ -281,10 +284,10 @@ class Less(Comparison):
         return current_pressure < reference_pressure
 
     def export(self, fmt):
-        if fmt == 'latex':
-            return self.node + " is less than " + str(round(self.reference_pressure)) + "psi"
+        if fmt == top.ExportFormat.Latex:
+            return f'{self.node} is less than {round(self.reference_pressure)}psi'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class Greater(Comparison):
@@ -295,10 +298,10 @@ class Greater(Comparison):
         return current_pressure > reference_pressure
 
     def export(self, fmt):
-        if fmt == 'latex':
-            return self.node + " is greater than " + str(round(self.reference_pressure)) + "psi"
+        if fmt == top.ExportFormat.Latex:
+            return f'{self.node} is greater than {round(self.reference_pressure)}psi'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class LessEqual(Comparison):
@@ -309,10 +312,10 @@ class LessEqual(Comparison):
         return current_pressure <= reference_pressure
 
     def export(self, fmt):
-        if fmt == 'latex':
-            return self.node + " is less than or equal to " + str(round(self.reference_pressure)) + "psi"
+        if fmt == top.ExportFormat.Latex:
+            return f'{self.node} is less than or equal to {round(self.reference_pressure)}psi'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
 class GreaterEqual(Comparison):
@@ -323,7 +326,7 @@ class GreaterEqual(Comparison):
         return current_pressure >= reference_pressure
 
     def export(self, fmt):
-        if fmt == 'latex':
-            return self.node + " is greater than or equal to " + str(round(self.reference_pressure)) + "psi"
+        if fmt == top.ExportFormat.Latex:
+            return f'{self.node} is greater than or equal to {round(self.reference_pressure)}psi'
         else:
-            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+            raise NotImplementedError(f'Format "{fmt}" not supported')

--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -147,6 +147,12 @@ class WaitUntil:
     def __eq__(self, other):
         return type(self) == type(other) and self.target_t == other.target_t
 
+    def export(self, fmt):
+        if fmt == 'latex':
+            return f'{round(self.target_t / 1e6)} seconds'
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+
 
 class Comparison:
     """Base class for conditions comparing a pressure to a reference."""
@@ -256,6 +262,12 @@ class Less(Comparison):
         """Compare pressures using less-than."""
         return current_pressure < reference_pressure
 
+    def export(self, fmt):
+        if fmt == 'latex':
+            return self.node + " is less than " + str(round(self.reference_pressure)) + "psi"
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
+
 
 class Greater(Comparison):
     """Condition that tests if a pressure is greater than a reference."""
@@ -263,6 +275,12 @@ class Greater(Comparison):
     def compare(self, current_pressure, reference_pressure):
         """Compare pressures using greater-than."""
         return current_pressure > reference_pressure
+
+    def export(self, fmt):
+        if fmt == 'latex':
+            return self.node + " is greater than " + str(round(self.reference_pressure)) + "psi"
+        else:
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
 
 
 class LessEqual(Comparison):

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -98,7 +98,11 @@ class ProcedureStep:
 
     def export(self, fmt):
         if fmt == "latex":
-            return self.action.export(fmt)
+            retval = ''
+            if self.operator != '':
+                retval += '\\' + self.operator + '{} '
+            retval += self.action.export(fmt)
+            return retval
         else:
             raise NotImplementedError("")
 
@@ -214,8 +218,15 @@ class ProcedureSuite:
     def __getitem__(self, key):
         return self.procedures[key]
 
-    def export(self, fmt="ProcLang"):
-        if fmt == "ProcLang":
-            return "\n".join([self.procedures[proc].export(fmt) for proc in self.procedures])
+    def export(self, fmt):
+        if fmt == 'latex':
+            exported_procedures = []
+            exported_procedures.append(self.procedures[self.starting_procedure_id].export(fmt))
+            for proc in self.procedures:
+                if proc == self.starting_procedure_id:
+                    continue
+                exported_procedures.append(self.procedures[proc].export(fmt))
+            return '\n\n'.join(exported_procedures)
+            return '\n'.join([self.procedures[proc].export(fmt) for proc in sorted(self.procedures)])
         else:
-            raise NotImplementedError(f"Format \"{fmt}\" not supported")
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -22,6 +22,17 @@ class StateChangeAction:
     component: str
     state: str
 
+    def export(self, fmt):
+        if fmt == "latex":
+            if self.state == "open":
+                return "Open " + self.component
+            elif self.state == "closed":
+                return "Close " + self.component
+            else:
+                return "Set " + self.component + " to " + self.state
+        else:
+            raise NotImplementedError("")
+
 
 @dataclass
 class MiscAction:
@@ -85,6 +96,12 @@ class ProcedureStep:
     conditions: list
     operator: str
 
+    def export(self, fmt):
+        if fmt == "latex":
+            return self.action.export(fmt)
+        else:
+            raise NotImplementedError("")
+
 
 class Procedure:
     """A sequence of discrete procedure steps."""
@@ -140,6 +157,18 @@ class Procedure:
             self.procedure_id == other.procedure_id and \
             self.step_list == other.step_list
 
+    def export(self, fmt):
+        if fmt == "latex":
+            export_val = f"\\subsection{{{self.procedure_id}}}"
+            if len(self.step_list) > 0:
+                export_val += "\n\\begin{checklist}"
+                for i in self.step_list:
+                    export_val += "\n    \\item " + i.export(fmt)
+                export_val += "\n\\end{checklist}"
+            return export_val
+        else:
+            raise NotImplementedError("")
+
 
 class ProcedureSuite:
     """A set of procedures and associated metadata."""
@@ -184,3 +213,9 @@ class ProcedureSuite:
 
     def __getitem__(self, key):
         return self.procedures[key]
+
+    def export(self, fmt="ProcLang"):
+        if fmt == "ProcLang":
+            return "\n".join([self.procedures[proc].export(fmt) for proc in self.procedures])
+        else:
+            raise NotImplementedError(f"Format \"{fmt}\" not supported")

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -31,7 +31,7 @@ class StateChangeAction:
             else:
                 return "Set " + self.component + " to " + self.state
         else:
-            raise NotImplementedError("")
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
 
 
 @dataclass
@@ -104,7 +104,7 @@ class ProcedureStep:
             retval += self.action.export(fmt)
             return retval
         else:
-            raise NotImplementedError("")
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
 
 
 class Procedure:
@@ -186,7 +186,7 @@ class Procedure:
                 export_val += "\n\\end{checklist}"
             return export_val
         else:
-            raise NotImplementedError("")
+            raise NotImplementedError(f'Format \"{fmt}\" not supported')
 
 
 class ProcedureSuite:

--- a/topside/procedures/tests/example.tex
+++ b/topside/procedures/tests/example.tex
@@ -1,0 +1,32 @@
+\subsection{main}
+\begin{checklist}
+    \item \PRIMARY{} Close series\_fill\_valve
+    \item Wait 5 seconds
+    \item \PRIMARY{} Open supply\_valve
+    \item If p1 is less than 600psi
+    \begin{checklist}
+        \item Begin abort\_1 procedure
+    \end{checklist}
+    \item If p1 is greater than 1000psi
+    \begin{checklist}
+        \item Begin abort\_2 procedure
+    \end{checklist}
+    \item \PRIMARY{} Open series\_fill\_valve
+    \item \PRIMARY{} Open remote\_fill\_valve
+    \item Wait 180 seconds
+    \item \PRIMARY{} Close remote\_fill\_valve
+    \item \PRIMARY{} Open remote\_vent\_valve
+\end{checklist}
+
+\subsection{abort\_1}
+\begin{checklist}
+    \item \SECONDARY{} Close supply\_valve
+    \item Wait 10 seconds
+    \item \SECONDARY{} Open remote\_vent\_valve
+\end{checklist}
+
+\subsection{abort\_2}
+\begin{checklist}
+    \item \CONTROL{} Close supply\_valve
+    \item \CONTROL{} Open line\_vent\_valve
+\end{checklist}

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -77,8 +77,9 @@ def test_proclang_file_latex_export():
     # Need to add newline to export since the tex file ends with a newline
     export += '\n'
 
+    filepath = os.path.join(os.path.dirname(__file__), 'example.tex')
     expected_export = ''
-    with open('example.tex', 'r') as f:
+    with open(filepath, 'r') as f:
         expected_export = f.read()
 
     assert export == expected_export

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -1,0 +1,21 @@
+import pytest
+import topside as top
+
+
+def test_procedure_latex_export():
+    s1 = top.ProcedureStep('s1', top.Action("remote fill valve", "open"), [])
+    s2 = top.ProcedureStep('s2', top.Action("remote vent valve", "closed"), [])
+
+    proc = top.Procedure('p1', [s1, s2])
+
+    export = proc.export("latex")
+
+    print(export)
+
+    expected_export = r"""\subsection{p1}
+\begin{checklist}
+    \item Open remote fill valve
+    \item Close remote vent valve
+\end{checklist}"""
+    print(expected_export)
+    assert export == expected_export

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -82,3 +82,28 @@ def test_proclang_file_latex_export():
         expected_export = f.read()
 
     assert export == expected_export
+
+
+def test_waituntil_latex_export():
+    suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.And([top.WaitUntil(10e6), top.Or([top.Less('p1', 400.0),
+                                                       top.GreaterEqual('p2', 17.0)])]), top.Transition('main', '2'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')
+        ])
+    ])
+
+    export = suite.export('latex')
+
+    print(export)
+
+    expected_export = r'''\subsection{main}
+\begin{checklist}
+    \item \PRIMARY{} Open injector\_valve
+    \item Wait 10 seconds and p1 is less than 400psi or p2 is greater than or equal to 17psi
+    \item \PRIMARY{} Close vent\_valve
+\end{checklist}'''
+
+    assert export == expected_export

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -1,6 +1,9 @@
-import pytest
-import topside as top
 import os
+
+import pytest
+import textwrap
+
+import topside as top
 
 
 def test_procedure_latex_export():
@@ -10,13 +13,14 @@ def test_procedure_latex_export():
 
     proc = top.Procedure('p1', [s1, s2])
 
-    export = proc.export('latex')
+    export = proc.export(top.ExportFormat.Latex)
 
-    expected_export = r'''\subsection{p1}
-\begin{checklist}
-    \item \PRIMARY{} Open remote fill valve
-    \item \SECONDARY{} Close remote vent valve
-\end{checklist}'''
+    expected_export = textwrap.dedent(r'''        \subsection{p1}
+        \begin{checklist}
+            \item \PRIMARY{} Open remote fill valve
+            \item \SECONDARY{} Close remote vent valve
+        \end{checklist}''')
+
     assert export == expected_export
 
 
@@ -30,18 +34,18 @@ def test_procedure_suite_latex_export():
 
     suite = top.ProcedureSuite([proc_main, proc_abort])
 
-    export = suite.export('latex')
+    export = suite.export(top.ExportFormat.Latex)
 
-    expected_export = r'''\subsection{main}
-\begin{checklist}
-    \item \PRIMARY{} Open remote fill valve
-    \item \SECONDARY{} Close remote vent valve
-\end{checklist}
+    expected_export = textwrap.dedent(r'''        \subsection{main}
+        \begin{checklist}
+            \item \PRIMARY{} Open remote fill valve
+            \item \SECONDARY{} Close remote vent valve
+        \end{checklist}
 
-\subsection{abort}
-\begin{checklist}
-    \item \SECONDARY{} Close remote vent valve
-\end{checklist}'''
+        \subsection{abort}
+        \begin{checklist}
+            \item \SECONDARY{} Close remote vent valve
+        \end{checklist}''')
 
     assert export == expected_export
 
@@ -56,23 +60,23 @@ def test_waituntil_latex_export():
         ])
     ])
 
-    export = suite.export('latex')
+    export = suite.export(top.ExportFormat.Latex)
 
     print(export)
 
-    expected_export = r'''\subsection{main}
-\begin{checklist}
-    \item \PRIMARY{} Open injector\_valve
-    \item Wait 10 seconds
-    \item \PRIMARY{} Close vent\_valve
-\end{checklist}'''
+    expected_export = textwrap.dedent(r'''        \subsection{main}
+        \begin{checklist}
+            \item \PRIMARY{} Open injector\_valve
+            \item Wait 10 seconds
+            \item \PRIMARY{} Close vent\_valve
+        \end{checklist}''')
 
     assert export == expected_export
 
 
 def test_proclang_file_latex_export():
     filepath = os.path.join(os.path.dirname(__file__), 'example.proc')
-    export = top.proclang.parse_from_file(filepath).export('latex')
+    export = top.proclang.parse_from_file(filepath).export(top.ExportFormat.Latex)
 
     # Need to add newline to export since the tex file ends with a newline
     export += '\n'
@@ -96,15 +100,15 @@ def test_waituntil_latex_export():
         ])
     ])
 
-    export = suite.export('latex')
+    export = suite.export(top.ExportFormat.Latex)
 
     print(export)
 
-    expected_export = r'''\subsection{main}
-\begin{checklist}
-    \item \PRIMARY{} Open injector\_valve
-    \item Wait 10 seconds and p1 is less than 400psi or p2 is greater than or equal to 17psi
-    \item \PRIMARY{} Close vent\_valve
-\end{checklist}'''
+    expected_export = textwrap.dedent(r'''        \subsection{main}
+        \begin{checklist}
+            \item \PRIMARY{} Open injector\_valve
+            \item Wait 10 seconds and p1 is less than 400psi or p2 is greater than or equal to 17psi
+            \item \PRIMARY{} Close vent\_valve
+        \end{checklist}''')
 
     assert export == expected_export

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -3,19 +3,45 @@ import topside as top
 
 
 def test_procedure_latex_export():
-    s1 = top.ProcedureStep('s1', top.Action("remote fill valve", "open"), [])
-    s2 = top.ProcedureStep('s2', top.Action("remote vent valve", "closed"), [])
+    s1 = top.ProcedureStep('s1', top.StateChangeAction('remote fill valve', 'open'), [], 'PRIMARY')
+    s2 = top.ProcedureStep('s2', top.StateChangeAction(
+        'remote vent valve', 'closed'), [], 'SECONDARY')
 
     proc = top.Procedure('p1', [s1, s2])
 
-    export = proc.export("latex")
+    export = proc.export('latex')
+
+    expected_export = r'''\subsection{p1}
+\begin{checklist}
+    \item \PRIMARY{} Open remote fill valve
+    \item \SECONDARY{} Close remote vent valve
+\end{checklist}'''
+    assert export == expected_export
+
+
+def test_procedure_suite_latex_export():
+    s1 = top.ProcedureStep('s1', top.StateChangeAction('remote fill valve', 'open'), [], 'PRIMARY')
+    s2 = top.ProcedureStep('s2', top.StateChangeAction(
+        'remote vent valve', 'closed'), [], 'SECONDARY')
+
+    proc_main = top.Procedure('main', [s1, s2])
+    proc_abort = top.Procedure('abort', [s2])
+
+    suite = top.ProcedureSuite([proc_main, proc_abort])
+
+    export = suite.export('latex')
 
     print(export)
 
-    expected_export = r"""\subsection{p1}
+    expected_export = r'''\subsection{main}
 \begin{checklist}
-    \item Open remote fill valve
-    \item Close remote vent valve
-\end{checklist}"""
-    print(expected_export)
+    \item \PRIMARY{} Open remote fill valve
+    \item \SECONDARY{} Close remote vent valve
+\end{checklist}
+
+\subsection{abort}
+\begin{checklist}
+    \item \SECONDARY{} Close remote vent valve
+\end{checklist}'''
+
     assert export == expected_export

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -1,7 +1,7 @@
 import os
+import textwrap
 
 import pytest
-import textwrap
 
 import topside as top
 
@@ -62,8 +62,6 @@ def test_waituntil_latex_export():
 
     export = suite.export(top.ExportFormat.Latex)
 
-    print(export)
-
     expected_export = textwrap.dedent(r'''        \subsection{main}
         \begin{checklist}
             \item \PRIMARY{} Open injector\_valve
@@ -101,8 +99,6 @@ def test_waituntil_latex_export():
     ])
 
     export = suite.export(top.ExportFormat.Latex)
-
-    print(export)
 
     expected_export = textwrap.dedent(r'''        \subsection{main}
         \begin{checklist}


### PR DESCRIPTION
It now exports full procedureSuites, which is nice.

It does not generate a full, compilable latex file by design, since there's a bunch of extra stuff we add to our ops files (operator macro defines, titles, etc) that aren't present in the proclang files.

Tests include generating a full procedureSuite export from `example.proc`, so I'm confident that it works for full procedures.

Not using an enum for `fmt` in export functions because neither `procedures.py` nor `conditions.py` import `topside`, which would be necessary for them to share an enum (I think), and I'm scared of adding that as an import since I don't know if it causes recursion problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/90)
<!-- Reviewable:end -->
