### PR TITLE
app: Draw only one label per plumbing component

### DIFF
--- a/application/visualization_area.py
+++ b/application/visualization_area.py
@@ -202,7 +202,7 @@ class VisualizationArea(QQuickPaintedItem):
 
         painter.setFont(self.node_font)
         for orig_node in self.engine_instance.nodes(data=False):
-            if orig_node != 'atm':
+            if orig_node != top.ATM:
                 node_pos = self.layout_pos[orig_node]
                 painter.drawText(node_pos[0] + text_offset[0],
                                  node_pos[1] + text_offset[1], str(orig_node))

--- a/topside/visualization/layout.py
+++ b/topside/visualization/layout.py
@@ -42,5 +42,5 @@ def terminal_graph(plumbing_engine):
 
 
 def component_nodes(plumbing_engine):
-    return [[name + '.' + str(node) for node in c.component_graph]
-            for name, c in plumbing_engine.component_dict.items()]
+    return {name: [name + '.' + str(node) for node in c.component_graph]
+            for name, c in plumbing_engine.component_dict.items()}

--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -130,7 +130,7 @@ def layout_plumbing_engine(plumbing_engine):
         that the node should be placed at.
     """
     t = top.terminal_graph(plumbing_engine)
-    components = top.component_nodes(plumbing_engine)
+    components = list(top.component_nodes(plumbing_engine).values())
 
     node_indices = {n: i for i, n in enumerate(t.nodes)}
 

--- a/topside/visualization/tests/test_layout.py
+++ b/topside/visualization/tests/test_layout.py
@@ -89,7 +89,7 @@ def test_component_nodes_one_component():
     p = one_component_engine()
     nodes = top.component_nodes(p)
 
-    expected_component_nodes = [['c1.1', 'c1.2']]
+    expected_component_nodes = {'c1': ['c1.1', 'c1.2']}
     assert nodes == expected_component_nodes
 
 
@@ -97,7 +97,7 @@ def test_component_nodes_series_components():
     p = series_component_engine()
     nodes = top.component_nodes(p)
 
-    expected_component_nodes = [['c1.1', 'c1.2'], ['c2.1', 'c2.2']]
+    expected_component_nodes = {'c1': ['c1.1', 'c1.2'], 'c2': ['c2.1', 'c2.2']}
     assert nodes == expected_component_nodes
 
 
@@ -105,5 +105,5 @@ def test_component_nodes_parallel_components():
     p = parallel_component_engine()
     nodes = top.component_nodes(p)
 
-    expected_component_nodes = [['c1.1', 'c1.2'], ['c2.1', 'c2.2']]
+    expected_component_nodes = {'c1': ['c1.1', 'c1.2'], 'c2': ['c2.1', 'c2.2']}
     assert nodes == expected_component_nodes


### PR DESCRIPTION
Instead of labelling every node in the visualization, determine which
nodes belong to components and only label the component once.
De-clutters the visualization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/91)
<!-- Reviewable:end -->
