### PR TITLE
Dedent tests, adjust parser API

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,8 +47,6 @@ jobs:
         # here (F): https://flake8.pycqa.org/en/latest/user/error-codes.html
         # and here (E): https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
         flake8 . --select=E9,F63,F7,F82
-        # exit-zero treats all errors as warnings.
-        flake8 . --exit-zero
 
     - name: Test with pytest
       run: |

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -18,7 +18,7 @@ class Parser:
         files: iterable
             files is the iterable (usually a list) of one or more paths of the PDL files we
             want parsed. Alternatively, it can also be a list of strings that are each a valid
-            PDL file.
+            PDL file. Alternatively, a single string or file path is also acceptable.
 
         input_type: char
             input_type indicates whether the argument provided to "files" is
@@ -26,6 +26,11 @@ class Parser:
 
         """
         file_list = []
+
+        # if a single element, put into list for processing
+        if not hasattr(files, '__iter__') or isinstance(files, str):
+            files = [files]
+
         for file in files:
             file_list.append(top.File(file, input_type))
         self.package = top.Package(file_list)

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -28,7 +28,7 @@ class Parser:
         file_list = []
 
         # if a single element, put into list for processing
-        if not hasattr(files, '__iter__') or isinstance(files, str):
+        if isinstance(files, str):
             files = [files]
 
         for file in files:

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 
 import topside as top
 import topside.pdl.exceptions as exceptions
@@ -17,22 +18,21 @@ def test_valid_pdl():
 
 
 def test_no_import():
-    no_import =\
-        """
-name: example
-body:
-- typedef:
-    params: [edge_name, open_teq, closed_teq]
-    name: valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: open_teq
-      closed:
-        edge1: closed_teq
-"""
+    no_import = textwrap.dedent("""\
+    name: example
+    body:
+    - typedef:
+        params: [edge_name, open_teq, closed_teq]
+        name: valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: open_teq
+          closed:
+            edge1: closed_teq
+    """)
     file = top.File(no_import, 's')
 
     assert file.namespace == 'example'
@@ -42,144 +42,138 @@ body:
 
 
 def test_invalid_typedef():
-    no_params =\
-        """
-name: example
-import: [stdlib]
-body:
-- typedef:
-    params:
-    name: valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: open_teq
-      closed:
-        edge1: closed_teq
-"""
+    no_params = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - typedef:
+        params:
+        name: valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: open_teq
+          closed:
+            edge1: closed_teq
+    """)
 
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(no_params, input_type='s')
 
 
 def test_invalid_no_component_name():
-    no_name =\
-        """
-name: example
-import: [stdlib]
-body:
-- component:
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: 1
-      closed:
-        edge1: closed
-"""
+    no_name =textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: 1
+          closed:
+            edge1: closed
+    """)
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(no_name, input_type='s')
 
 
 def test_invalid_no_state_no_teq():
 
-    no_state_no_teq =\
-        """
-name: example
-import: [stdlib]
-body:
-- component:
-    name: vent_plug
-    edges:
-      edge1:
-        nodes: [0, 1]
-"""
+    no_state_no_teq = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: vent_plug
+        edges:
+          edge1:
+            nodes: [0, 1]
+    """)
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(no_state_no_teq, input_type='s')
 
 
 def test_invalid_param_missing():
-    param_missing =\
-        """
-name: example
-import: [stdlib]
-body:
-- typedef:
-    params: [edge1, open_teq, closed_teq]
-    name: valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: open_teq
-      closed:
-        edge1: closed_teq
-- component:
-    name: vent_valve
-    type: valve
-    params:
-      open_teq: 1
-      closed_teq: closed
-"""
+    param_missing = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - typedef:
+        params: [edge1, open_teq, closed_teq]
+        name: valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: open_teq
+          closed:
+            edge1: closed_teq
+    - component:
+        name: vent_valve
+        type: valve
+        params:
+          open_teq: 1
+          closed_teq: closed
+    """)
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(param_missing, input_type='s')
 
 
 def test_invalid_no_hoisting():
-    no_hoisting =\
-        """
-name: example
-import: [stdlib]
-body:
-- component:
-    name: vent_valve
-    type: valve
-    params:
-      edge1: fav_edge
-      open_teq: 1
-      closed_teq: closed
-- typedef:
-    params: [edge1, open_teq, closed_teq]
-    name: valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: open_teq
-      closed:
-        edge1: closed_teq
-"""
+    no_hoisting = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: vent_valve
+        type: valve
+        params:
+          edge1: fav_edge
+          open_teq: 1
+          closed_teq: closed
+    - typedef:
+        params: [edge1, open_teq, closed_teq]
+        name: valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: open_teq
+          closed:
+            edge1: closed_teq
+    """)
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(no_hoisting, input_type='s')
 
 
 def test_invalid_incomplete_node():
     # A is missing its components
-    incomplete_nodes =\
-        """
-name: example
-import: [stdlib]
-body:
-- graph:
-    name: main
-    nodes:
-      A:
-        fixed_pressure: 500
+    incomplete_nodes = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - graph:
+        name: main
+        nodes:
+          A:
+            fixed_pressure: 500
 
-      B:
-        components:
-          - [fill_valve, 1]
+          B:
+            components:
+              - [fill_valve, 1]
 
-    states:
-      fill_valve: closed
-      vent_valve: open
-      three_way_valve: left
-"""
+        states:
+          fill_valve: closed
+          vent_valve: open
+          three_way_valve: left
+    """)
 
     with pytest.raises(exceptions.BadInputError):
         _ = top.File(incomplete_nodes, 's')

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -1,5 +1,6 @@
-import pytest
 import textwrap
+
+import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions

--- a/topside/pdl/tests/test_file.py
+++ b/topside/pdl/tests/test_file.py
@@ -64,7 +64,7 @@ def test_invalid_typedef():
 
 
 def test_invalid_no_component_name():
-    no_name =textwrap.dedent("""\
+    no_name = textwrap.dedent("""\
     name: example
     import: [stdlib]
     body:

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 
 import topside as top
 import topside.pdl.exceptions as exceptions
@@ -84,23 +85,22 @@ def test_files_unchanged():
 
 def test_invalid_import():
     bad_import = "NONEXISTENT"
-    invalid_import =\
-        f"""
-name: example
-import: [stdlib, {bad_import}]
-body:
-- typedef:
-    params: [edge1, open_teq, closed_teq]
-    name: valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: open_teq
-      closed:
-        edge1: closed_teq
-"""
+    invalid_import = textwrap.dedent(f"""\
+    name: example
+    import: [stdlib, {bad_import}]
+    body:
+    - typedef:
+        params: [edge1, open_teq, closed_teq]
+        name: valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: open_teq
+          closed:
+            edge1: closed_teq
+    """)
     invalid_import_file = top.File(invalid_import, input_type='s')
     with pytest.raises(exceptions.BadInputError):
         top.Package([invalid_import_file])
@@ -111,19 +111,18 @@ def test_invalid_bad_import_type():
     # level, not at the file one. We can look at changing this if we change the implementation of
     # how importable files are stored.
     bad_type = "NONEXISTENT_TYPE"
-    bad_imported_type =\
-        f"""
-name: example
-import: [stdlib]
-body:
-- component:
-    name: vent_valve
-    type: stdlib.{bad_type}
-    params:
-      edge_name: fav_edge
-      open_teq: 5
-      closed_teq: closed
-"""
+    bad_imported_type = textwrap.dedent(f"""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: vent_valve
+        type: stdlib.{bad_type}
+        params:
+          edge_name: fav_edge
+          open_teq: 5
+          closed_teq: closed
+    """)
     bad_imported_type_file = top.File(bad_imported_type, input_type='s')
     with pytest.raises(exceptions.BadInputError):
         top.Package([bad_imported_type_file])
@@ -135,88 +134,84 @@ def test_invalid_empty_package():
 
 
 def test_invalid_nested_import():
-    nested_import =\
-        """
-name: example
-import: [stdlib]
-body:
-- component:
-    name: vent_valve
-    type: stdlib.NEST.hole
-    params:
-      edge_name: fav_edge
-      open_teq: 5
-"""
+    nested_import = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: vent_valve
+        type: stdlib.NEST.hole
+        params:
+          edge_name: fav_edge
+          open_teq: 5
+    """)
     nested_import_file = top.File(nested_import, input_type='s')
     with pytest.raises(NotImplementedError):
         top.Package([nested_import_file])
 
 
 def test_duplicate_names():
-    file_1 =\
-        """
-name: name1
-body:
-- component:
-    name: fill_valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: 6
-      closed:
-        edge1: closed
-"""
+    file_1 = textwrap.dedent("""\
+    name: name1
+    body:
+    - component:
+        name: fill_valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: 6
+          closed:
+            edge1: closed
+    """)
 
-    file_2 =\
-        """
-name: name2
-body:
-- component:
-    name: fill_valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: 6
-      closed:
-        edge1: closed
-"""
+    file_2 = textwrap.dedent("""\
+    name: name2
+    body:
+    - component:
+        name: fill_valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: 6
+          closed:
+            edge1: closed
+    """)
     duplicate_pack = top.Package([top.File(file_1, 's'), top.File(file_2, 's')])
     assert duplicate_pack.component_dict["name1"][0]['name'] == "name1.fill_valve"
     assert duplicate_pack.component_dict["name2"][0]['name'] == "name2.fill_valve"
 
 
 def test_invalid_graph_missing_states():
-    missing_states =\
-        """
-name: example
-import: [stdlib]
-body:
-- component:
-    name: fill_valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: 6
-      closed:
-        edge1: closed
-- graph:
-    name: main
-    nodes:
-      A:
-        fixed_pressure: 500
-        components:
-          - [fill_valve, 0]
+    missing_states = textwrap.dedent("""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: fill_valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: 6
+          closed:
+            edge1: closed
+    - graph:
+        name: main
+        nodes:
+          A:
+            fixed_pressure: 500
+            components:
+              - [fill_valve, 0]
 
-      B:
-        components:
-          - [fill_valve, 1]
-"""
+          B:
+            components:
+              - [fill_valve, 1]
+    """)
     missing_states_file = top.File(missing_states, 's')
     with pytest.raises(exceptions.BadInputError):
         top.Package([missing_states_file])

--- a/topside/pdl/tests/test_package.py
+++ b/topside/pdl/tests/test_package.py
@@ -1,5 +1,6 @@
-import pytest
 import textwrap
+
+import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions
@@ -102,8 +103,9 @@ def test_invalid_import():
             edge1: closed_teq
     """)
     invalid_import_file = top.File(invalid_import, input_type='s')
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.Package([invalid_import_file])
+    assert "invalid import" in str(err)
 
 
 def test_invalid_bad_import_type():
@@ -124,13 +126,15 @@ def test_invalid_bad_import_type():
           closed_teq: closed
     """)
     bad_imported_type_file = top.File(bad_imported_type, input_type='s')
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.Package([bad_imported_type_file])
+    assert "invalid component" in str(err)
 
 
 def test_invalid_empty_package():
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.Package([])
+    assert "no Files" in str(err)
 
 
 def test_invalid_nested_import():
@@ -146,8 +150,9 @@ def test_invalid_nested_import():
           open_teq: 5
     """)
     nested_import_file = top.File(nested_import, input_type='s')
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError) as err:
         top.Package([nested_import_file])
+    assert "nested imports" in str(err)
 
 
 def test_duplicate_names():
@@ -213,5 +218,6 @@ def test_invalid_graph_missing_states():
               - [fill_valve, 1]
     """)
     missing_states_file = top.File(missing_states, 's')
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.Package([missing_states_file])
+    assert "missing component" in str(err)

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -1,5 +1,6 @@
-import pytest
 import textwrap
+
+import pytest
 
 import topside as top
 import topside.pdl.exceptions as exceptions
@@ -94,33 +95,34 @@ def test_invalid_main():
     - component:
         name: fill_valve
         edges:
-        edge1:
+          edge1:
             nodes: [0, 1]
         states:
-        open:
+          open:
             edge1: 6
-        closed:
+          closed:
             edge1: closed
     - graph:
         name: {not_main}
         nodes:
-        A:
+          A:
             fixed_pressure: 500
             components:
-            - [fill_valve, 0]
+              - [fill_valve, 0]
 
-        B:
+          B:
             components:
-            - [fill_valve, 1]
+              - [fill_valve, 1]
         states:
-            fill_valve: open
+          fill_valve: open
     """)
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.Parser([no_main_graph], 's')
+    assert "graph main" in str(err)
 
 
 def test_invalid_component():
-    low_teq = 0.000000001
+    low_teq = 1e-9
     teq_too_low = textwrap.dedent(f"""\
     name: example
     body:
@@ -221,8 +223,9 @@ def test_invalid_extract_edges():
         }
     }
 
-    with pytest.raises(exceptions.BadInputError):
+    with pytest.raises(exceptions.BadInputError) as err:
         top.extract_edges(too_many_nodes)
+    assert "malformed nodes" in str(err)
 
 
 def test_load_iterables():

--- a/topside/pdl/tests/test_parser.py
+++ b/topside/pdl/tests/test_parser.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 
 import topside as top
 import topside.pdl.exceptions as exceptions
@@ -78,69 +79,67 @@ def test_valid_file():
 
 def test_invalid_main():
     not_main = "NOT_MAIN"
-    no_main_graph =\
-        f"""
-name: example
-import: [stdlib]
-body:
-- component:
-    name: fill_valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: 6
-      closed:
-        edge1: closed
-- graph:
-    name: {not_main}
-    nodes:
-      A:
-        fixed_pressure: 500
-        components:
-          - [fill_valve, 0]
+    no_main_graph = textwrap.dedent(f"""\
+    name: example
+    import: [stdlib]
+    body:
+    - component:
+        name: fill_valve
+        edges:
+        edge1:
+            nodes: [0, 1]
+        states:
+        open:
+            edge1: 6
+        closed:
+            edge1: closed
+    - graph:
+        name: {not_main}
+        nodes:
+        A:
+            fixed_pressure: 500
+            components:
+            - [fill_valve, 0]
 
-      B:
-        components:
-          - [fill_valve, 1]
-    states:
-        fill_valve: open
-"""
+        B:
+            components:
+            - [fill_valve, 1]
+        states:
+            fill_valve: open
+    """)
     with pytest.raises(exceptions.BadInputError):
         top.Parser([no_main_graph], 's')
 
 
 def test_invalid_component():
     low_teq = 0.000000001
-    teq_too_low =\
-        f"""
-name: example
-body:
-- component:
-    name: fill_valve
-    edges:
-      edge1:
-        nodes: [0, 1]
-    states:
-      open:
-        edge1: {low_teq}
-      closed:
-        edge1: closed
-- graph:
-    name: main
-    nodes:
-      A:
-        fixed_pressure: 500
-        components:
-          - [fill_valve, 0]
+    teq_too_low = textwrap.dedent(f"""\
+    name: example
+    body:
+    - component:
+        name: fill_valve
+        edges:
+          edge1:
+            nodes: [0, 1]
+        states:
+          open:
+            edge1: {low_teq}
+          closed:
+            edge1: closed
+    - graph:
+        name: main
+        nodes:
+          A:
+            fixed_pressure: 500
+            components:
+              - [fill_valve, 0]
 
-      B:
-        components:
-          - [fill_valve, 1]
-    states:
-      fill_valve: open
-    """
+          B:
+            components:
+              - [fill_valve, 1]
+        states:
+          fill_valve: open
+    """)
 
     # this shouldn't raise an error, invalid components are legal
     parse = top.Parser([teq_too_low], 's')


### PR DESCRIPTION
Used `textwrap.dedent` on the long PDL strings in our PDL tests to make them prettier. Also made a small, non-breaking adjustment to the parser API that allows it to take in a single string if only passing in a single file, rather than forcing the user to place the file in an iterable.

Also added a quick additional unit test to check that loading different types of iterables actually works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/92)
<!-- Reviewable:end -->
