### PR TITLE
viz: Stop calculating unused constraint Hessian

### DIFF
--- a/topside/visualization/optimization/optimization.py
+++ b/topside/visualization/optimization/optimization.py
@@ -47,9 +47,8 @@ def make_constraints(components, node_indices):
 
         cons_f = partial(top.right_angle_cons_f, i, j)
         cons_j = partial(top.right_angle_cons_j, i, j)
-        cons_h = partial(top.right_angle_cons_h, i, j)
 
-        cons = NonlinearConstraint(cons_f, 0, 0, jac=cons_j, hess=cons_h)
+        cons = NonlinearConstraint(cons_f, 0, 0, jac=cons_j)
 
         constraints.append(cons)
 


### PR DESCRIPTION
SciPy kept giving us warnings that SLSQP ignores the constraint Hessian.
Since we don't have any current plans to switch away from SLSQP, we can
just not calculate the Hessian, which makes stdout a bit quieter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/98)
<!-- Reviewable:end -->
