### PR TITLE
proc: Add misc actions to ProcLang

### DIFF
--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 import enum
-import typing
 
 import topside as top
 

--- a/topside/procedures/procedure.py
+++ b/topside/procedures/procedure.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import enum
+import typing
 
 import topside as top
 
@@ -8,8 +9,14 @@ class ExportFormat(enum.Enum):
     Latex = 1
 
 
+# TODO(jacob): Investigate whether this would be better as a variant
+# rather than a base class.
+class Action:
+    pass
+
+
 @dataclass
-class StateChangeAction:
+class StateChangeAction(Action):
     """
     A state change for a single component in the plumbing engine.
 
@@ -42,7 +49,7 @@ class StateChangeAction:
 
 
 @dataclass
-class MiscAction:
+class MiscAction(Action):
     """
     A procedure action that does not fit into any other category.
 
@@ -105,7 +112,7 @@ class ProcedureStep:
         The person who performs the step
     """
     step_id: str
-    action: StateChangeAction
+    action: Action
     conditions: list
     operator: str
 

--- a/topside/procedures/proclang.py
+++ b/topside/procedures/proclang.py
@@ -18,7 +18,7 @@ procedure: name ":" step+
 name: NAME
 
 step: step_id "." personnel ":" [condition] action deviation*
-step_id: NAME
+step_id: (LETTER | DIGIT | "_")+
 personnel: NAME
 
 action: state_change_action | misc_action
@@ -27,7 +27,7 @@ state_change_action: ( "set" | "Set" ) component "to" state
 component: NAME
 state: NAME
 
-misc_action: STRING
+misc_action: SENTENCE
 
 deviation: "-" condition transition
 transition: name "." step_id
@@ -57,8 +57,8 @@ operator: "<"    -> lt
         | ">="   -> ge
         | "=="   -> eq
 
-NAME: (LETTER | DIGIT) (LETTER | DIGIT | "_")*
-STRING: (LETTER) (LETTER | DIGIT | "_" | " ")*
+NAME: (LETTER | "_") (LETTER | DIGIT | "_")*
+SENTENCE: (LETTER) (LETTER | DIGIT | "_" | " ")*
 '''
 
 parser = Lark(grammar, start='document')

--- a/topside/procedures/proclang.py
+++ b/topside/procedures/proclang.py
@@ -15,15 +15,19 @@ grammar = '''
 
 document: procedure*
 procedure: name ":" step+
-name: STRING
+name: NAME
 
 step: step_id "." personnel ":" [condition] action deviation*
-step_id: STRING
-personnel: STRING
+step_id: NAME
+personnel: NAME
 
-action: "set" component "to" state
-component: STRING
-state: STRING
+action: state_change_action | misc_action
+
+state_change_action: ( "set" | "Set" ) component "to" state
+component: NAME
+state: NAME
+
+misc_action: STRING
 
 deviation: "-" condition transition
 transition: name "." step_id
@@ -45,7 +49,7 @@ logic_and : "and" | "&&" | "AND"
 logic_or  : "or" | "||" | "OR"
 
 // TODO(jacob): Add support for tolerance in equality comparison.
-node: STRING
+node: NAME
 value: NUMBER
 operator: "<"    -> lt
         | ">"    -> gt
@@ -53,7 +57,8 @@ operator: "<"    -> lt
         | ">="   -> ge
         | "=="   -> eq
 
-STRING: (LETTER | DIGIT) (LETTER | DIGIT | "_")*
+NAME: (LETTER | DIGIT) (LETTER | DIGIT | "_")*
+STRING: (LETTER) (LETTER | DIGIT | "_" | " ")*
 '''
 
 parser = Lark(grammar, start='document')
@@ -176,7 +181,7 @@ class ProcedureTransformer(Transformer):
 
     def transition(self, data):
         """
-        Process `waituntil` nodes in the parse tree.
+        Process `transition` nodes in the parse tree.
 
         `data` is a tuple of the form (procedure, step).
         """
@@ -185,12 +190,28 @@ class ProcedureTransformer(Transformer):
 
     def action(self, data):
         """
-        Process `waituntil` nodes in the parse tree.
+        Process `action` nodes in the parse tree.
+
+        `data` is a list of the form [action].
+        """
+        return data[0]
+
+    def state_change_action(self, data):
+        """
+        Process `state_change_action` nodes in the parse tree.
 
         `data` is a tuple of the form (component, state).
         """
         component, state = data
         return top.StateChangeAction(component, state)
+
+    def misc_action(self, data):
+        """
+        Process `misc_action` nodes in the parse tree.
+
+        `data` is a list of the form [action].
+        """
+        return top.MiscAction(data[0])
 
     def step(self, data):
         """
@@ -211,7 +232,7 @@ class ProcedureTransformer(Transformer):
         step_info['personnel'] = data[1]
         step_info['conditions_out'] = []
 
-        if type(data[2]) == top.StateChangeAction:  # Step has no attached entry condition
+        if isinstance(data[2], top.Action):  # Step has no attached entry condition
             step_info['condition_in'] = top.Immediate()
             step_info['action'] = data[2]
             deviations = data[3:]

--- a/topside/procedures/tests/example.proc
+++ b/topside/procedures/tests/example.proc
@@ -1,17 +1,20 @@
 main:
-    1. PRIMARY: set series_fill_valve to closed
-    2. PRIMARY: [5s] set supply_valve to open
+    1. PRIMARY: Set series_fill_valve to closed
+    2. PRIMARY: [5s] Set supply_valve to open
         - [p1 < 600] abort_1.1
         - [p1 > 1000] abort_2.1
-    3. PRIMARY: set series_fill_valve to open
-    4. PRIMARY: set remote_fill_valve to open
-    5. PRIMARY: [180s] set remote_fill_valve to closed
-    6. PRIMARY: set remote_vent_valve to open
+    3. PRIMARY: Set series_fill_valve to open
+    4. PRIMARY: Set remote_fill_valve to open
+    5. PRIMARY: [180s] Set remote_fill_valve to closed
+    6. PRIMARY: Set remote_vent_valve to open
+    7. OPS: Proceed with teardown
 
 abort_1:
-    1. SECONDARY: set supply_valve to closed
-    2. SECONDARY: [10s] set remote_vent_valve to open
+    1. SECONDARY: Set supply_valve to closed
+    2. SECONDARY: [10s] Set remote_vent_valve to open
+    3. OPS: Proceed with teardown
 
 abort_2:
-    1. CONTROL: set supply_valve to closed
-    2. CONTROL: set line_vent_valve to open
+    1. CONTROL: Set supply_valve to closed
+    2. CONTROL: Set line_vent_valve to open
+    3. OPS: Proceed with teardown

--- a/topside/procedures/tests/example.tex
+++ b/topside/procedures/tests/example.tex
@@ -16,6 +16,7 @@
     \item Wait 180 seconds
     \item \PRIMARY{} Close remote\_fill\_valve
     \item \PRIMARY{} Open remote\_vent\_valve
+    \item \OPS{} Proceed with teardown
 \end{checklist}
 
 \subsection{abort\_1}
@@ -23,10 +24,12 @@
     \item \SECONDARY{} Close supply\_valve
     \item Wait 10 seconds
     \item \SECONDARY{} Open remote\_vent\_valve
+    \item \OPS{} Proceed with teardown
 \end{checklist}
 
 \subsection{abort\_2}
 \begin{checklist}
     \item \CONTROL{} Close supply\_valve
     \item \CONTROL{} Open line\_vent\_valve
+    \item \OPS{} Proceed with teardown
 \end{checklist}

--- a/topside/procedures/tests/test_procedure.py
+++ b/topside/procedures/tests/test_procedure.py
@@ -236,3 +236,11 @@ def test_procedure_suite_indexing():
     suite = top.ProcedureSuite([proc_1, proc_2], 'p1')
 
     assert suite['p1'] == proc_1
+
+
+def test_action_types():
+    a1 = top.StateChangeAction('p1', 'open')
+    a2 = top.MiscAction('approach the tower')
+
+    assert isinstance(a1, top.Action)
+    assert isinstance(a2, top.Action)

--- a/topside/procedures/tests/test_proclang.py
+++ b/topside/procedures/tests/test_proclang.py
@@ -41,6 +41,26 @@ def test_parse_two_steps():
     assert suite == expected_suite
 
 
+def test_set_case_insensitive():
+    proclang = '''
+    main:
+        1. PRIMARY: Set injector_valve to open
+        2. PRIMARY: set injector_valve to open
+    '''
+    suite = top.proclang.parse(proclang)
+
+    expected_suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '2'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('2', top.StateChangeAction('injector_valve', 'open'), [], 'PRIMARY')
+        ])
+    ])
+
+    assert suite == expected_suite
+
+
 def test_parse_two_procedures():
     proclang = '''
     main:
@@ -263,21 +283,28 @@ def test_parse_from_file():
             top.ProcedureStep('5', top.StateChangeAction('remote_fill_valve', 'closed'), [
                 (top.Immediate(), top.Transition('main', '6'))
             ], 'PRIMARY'),
-            top.ProcedureStep('6', top.StateChangeAction(
-                'remote_vent_valve', 'open'), [], 'PRIMARY')
+            top.ProcedureStep('6', top.StateChangeAction('remote_vent_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '7'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('7', top.MiscAction('Proceed with teardown'), [], 'OPS')
         ]),
         top.Procedure('abort_1', [
             top.ProcedureStep('1', top.StateChangeAction('supply_valve', 'closed'), [
                 (top.WaitUntil(10e6), top.Transition('abort_1', '2'))
             ], 'SECONDARY'),
-            top.ProcedureStep('2', top.StateChangeAction(
-                'remote_vent_valve', 'open'), [], 'SECONDARY')
+            top.ProcedureStep('2', top.StateChangeAction('remote_vent_valve', 'open'), [
+                (top.Immediate(), top.Transition('abort_1', '3'))
+            ], 'SECONDARY'),
+            top.ProcedureStep('3', top.MiscAction('Proceed with teardown'), [], 'OPS')
         ]),
         top.Procedure('abort_2', [
             top.ProcedureStep('1', top.StateChangeAction('supply_valve', 'closed'), [
                 (top.Immediate(), top.Transition('abort_2', '2'))
             ], 'CONTROL'),
-            top.ProcedureStep('2', top.StateChangeAction('line_vent_valve', 'open'), [], 'CONTROL')
+            top.ProcedureStep('2', top.StateChangeAction('line_vent_valve', 'open'), [
+                (top.Immediate(), top.Transition('abort_2', '3'))
+            ], 'CONTROL'),
+            top.ProcedureStep('3', top.MiscAction('Proceed with teardown'), [], 'OPS')
         ]),
     ])
 
@@ -424,6 +451,34 @@ def test_parse_combined_conditions():
                 (comp_or, top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('s', 'v'), [], 'PRIMARY')
+        ])
+    ])
+
+    assert suite == expected_suite
+
+
+def test_parse_misc_actions():
+    proclang = '''
+    main:
+        1. CONTROL: Set injector_valve to open
+        2. CONTROL: [p1 < 10] Disarm the remote control system
+        3. PRIMARY: Approach the launch tower
+        4. OPS: [60s] Proceed with teardown
+    '''
+    suite = top.proclang.parse(proclang)
+
+    expected_suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Less('p1', 10), top.Transition('main', '2'))
+            ], 'CONTROL'),
+            top.ProcedureStep('2', top.MiscAction('Disarm the remote control system'), [
+                (top.Immediate(), top.Transition('main', '3'))
+            ], 'CONTROL'),
+            top.ProcedureStep('3', top.MiscAction('Approach the launch tower'), [
+                (top.WaitUntil(60e6), top.Transition('main', '4'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('4', top.MiscAction('Proceed with teardown'), [], 'OPS')
         ])
     ])
 


### PR DESCRIPTION
A misc action in ProcLang is any string that does not follow the "set
<component> to <state>" form.

As a driveby, also made the "set" in ProcLang state change actions
case-insensitive (for the starting letter).

Closes #87.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/100)
<!-- Reviewable:end -->
