### PR TITLE
proclang: Fix step ID bug, allow commas in misc actions

### DIFF
--- a/topside/procedures/proclang.py
+++ b/topside/procedures/proclang.py
@@ -18,7 +18,7 @@ procedure: name ":" step+
 name: NAME
 
 step: step_id "." personnel ":" [condition] action deviation*
-step_id: (LETTER | DIGIT | "_")+
+step_id: NAME_OR_NUMBER
 personnel: NAME
 
 action: state_change_action | misc_action
@@ -58,7 +58,8 @@ operator: "<"    -> lt
         | "=="   -> eq
 
 NAME: (LETTER | "_") (LETTER | DIGIT | "_")*
-SENTENCE: (LETTER) (LETTER | DIGIT | "_" | " ")*
+NAME_OR_NUMBER: (LETTER | DIGIT | "_")+
+SENTENCE: (LETTER) (LETTER | DIGIT | "_" | " " | ",")*
 '''
 
 parser = Lark(grammar, start='document')
@@ -296,9 +297,11 @@ class ProcedureTransformer(Transformer):
     component = handle_string
     state = handle_string
 
-    name = handle_string
     step_id = handle_string
     personnel = handle_string
+
+    name = handle_string
+    name_or_number = handle_string
 
 
 def parse(text):

--- a/topside/procedures/tests/test_proclang.py
+++ b/topside/procedures/tests/test_proclang.py
@@ -61,6 +61,54 @@ def test_set_case_insensitive():
     assert suite == expected_suite
 
 
+def test_different_step_ids():
+    proclang = '''
+    main:
+        1. PRIMARY: Set injector_valve to open
+        10. PRIMARY: Set injector_valve to open
+        100. PRIMARY: Set injector_valve to open
+        a. PRIMARY: Set injector_valve to open
+        ab. PRIMARY: Set injector_valve to open
+        a1. PRIMARY: Set injector_valve to open
+        1a. PRIMARY: Set injector_valve to open
+        a_1. PRIMARY: Set injector_valve to open
+        1_a. PRIMARY: Set injector_valve to open
+    '''
+    suite = top.proclang.parse(proclang)
+
+    expected_suite = top.ProcedureSuite([
+        top.Procedure('main', [
+            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '10'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('10', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '100'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('100', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', 'a'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('a', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', 'ab'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('ab', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', 'a1'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('a1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '1a'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('1a', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', 'a_1'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('a_1', top.StateChangeAction('injector_valve', 'open'), [
+                (top.Immediate(), top.Transition('main', '1_a'))
+            ], 'PRIMARY'),
+            top.ProcedureStep('1_a', top.StateChangeAction('injector_valve', 'open'), [], 'PRIMARY')
+        ])
+    ])
+
+    assert suite == expected_suite
+
+
 def test_parse_two_procedures():
     proclang = '''
     main:
@@ -462,7 +510,7 @@ def test_parse_misc_actions():
     main:
         1. CONTROL: Set injector_valve to open
         2. CONTROL: [p1 < 10] Disarm the remote control system
-        3. PRIMARY: Approach the launch tower
+        3. PRIMARY: Approach the launch tower, disconnect the cylinder, and replace the cap
         4. OPS: [60s] Proceed with teardown
     '''
     suite = top.proclang.parse(proclang)
@@ -475,7 +523,8 @@ def test_parse_misc_actions():
             top.ProcedureStep('2', top.MiscAction('Disarm the remote control system'), [
                 (top.Immediate(), top.Transition('main', '3'))
             ], 'CONTROL'),
-            top.ProcedureStep('3', top.MiscAction('Approach the launch tower'), [
+            top.ProcedureStep('3', top.MiscAction(
+                'Approach the launch tower, disconnect the cylinder, and replace the cap'), [
                 (top.WaitUntil(60e6), top.Transition('main', '4'))
             ], 'PRIMARY'),
             top.ProcedureStep('4', top.MiscAction('Proceed with teardown'), [], 'OPS')


### PR DESCRIPTION
The existing step ID implementation would error if a step ID longer than
one character was provided. Fixed the implementation and added a unit
test to verify it works.

Also added support for writing misc action descriptors containing
commas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/101)
<!-- Reviewable:end -->
