### PR TITLE
pdl: Patch a bug causing the application to hang

### DIFF
--- a/topside/pdl/package.py
+++ b/topside/pdl/package.py
@@ -36,7 +36,11 @@ class Package:
         """
         self.importable_files = dict()
 
-        imports_folder = os.listdir(utils.imports_path)
+        try:
+            imports_folder = os.listdir(utils.imports_path)
+        except FileNotFoundError:
+            imports_folder = []
+            warnings.warn(f"import directory {utils.imports_path} could not be found")
 
         for imported_file in imports_folder:
 


### PR DESCRIPTION
In the built application, the PDL import directory does not exist. This
causes Package instantiation to throw a FileNotFoundError, which hangs
the application. For now, since none of our PDL uses the import
directory, patch this by ignoring the error and raising a warning
instead. This only suppresses the error in the event that the import
directory is unused; if we actually need to import something, we will
get an error further down when we can't find that file. This is a
temporary workaround until we get dynamic import paths implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/104)
<!-- Reviewable:end -->
