### PR TITLE
app: Add real-time simulation and plotting

### DIFF
--- a/application/application.py
+++ b/application/application.py
@@ -10,7 +10,7 @@ from PySide2.QtQuickWidgets import QQuickWidget
 from .visualization_area import VisualizationArea
 from .procedures_bridge import ProceduresBridge
 from .plumbing_bridge import PlumbingBridge
-from .daq import DAQBridge, DAQPlotWidget
+from .daq import DAQBridge, DAQLayout
 
 
 # NOTE(jacob): `__file__` isn't defined for the frozen application,
@@ -61,10 +61,10 @@ class Application:
         self.daq_bridge.addChannel('A')
         self.daq_bridge.addChannel('B')
         self.daq_bridge.addChannel('C')
-        self.daq_bridge.addChannel('D')
-        self.daq_bridge.addChannel('E')
-        self.daq_bridge.addChannel('F')
-        self.daq_bridge.addChannel('G')
+        # self.daq_bridge.addChannel('D')
+        # self.daq_bridge.addChannel('E')
+        # self.daq_bridge.addChannel('F')
+        # self.daq_bridge.addChannel('G')
 
         # TODO(jacob): Currently we load these example files at startup
         # to make testing turnaround a bit faster. Figure out how to
@@ -84,7 +84,7 @@ class Application:
         horiz_splitter = QSplitter(Qt.Horizontal)
         horiz_splitter.setChildrenCollapsible(False)
 
-        daq_widget = DAQPlotWidget()
+        daq_widget = DAQLayout()
         self.daq_bridge.channelAdded.connect(daq_widget.addChannel)
         self.daq_bridge.channelRemoved.connect(daq_widget.removeChannel)
         self.daq_bridge.dataUpdated.connect(daq_widget.updateData)

--- a/application/application.py
+++ b/application/application.py
@@ -10,7 +10,7 @@ from PySide2.QtQuickWidgets import QQuickWidget
 from .visualization_area import VisualizationArea
 from .procedures_bridge import ProceduresBridge
 from .plumbing_bridge import PlumbingBridge
-from .daq import DAQBridge, DAQLayout
+from .daq import DAQBridge, make_daq_widget
 
 
 # NOTE(jacob): `__file__` isn't defined for the frozen application,
@@ -76,20 +76,11 @@ class Application:
         horiz_splitter = QSplitter(Qt.Horizontal)
         horiz_splitter.setChildrenCollapsible(False)
 
-        daq_widget = DAQLayout()
-
-        self.daq_bridge.channelAdded.connect(daq_widget.addChannel)
-        self.daq_bridge.channelRemoved.connect(daq_widget.removeChannel)
-        self.daq_bridge.dataUpdated.connect(daq_widget.updateData)
-
-        self.plumbing_bridge.engineLoaded.connect(daq_widget.channel_selector.updateNodeList)
-        daq_widget.channel_selector.channelSelected.connect(self.daq_bridge.addChannel)
-        daq_widget.channel_selector.channelDeselected.connect(self.daq_bridge.removeChannel)
-
+        daq_widget = make_daq_widget(self.daq_bridge, self.plumbing_bridge)
         horiz_splitter.addWidget(daq_widget)
 
         plumb_widget = make_qml_widget(self.qml_engine, 'PlumbingPane.qml')
-        plumb_widget.setMinimumWidth(400)
+        plumb_widget.setMinimumWidth(600)
         plumb_widget.setMinimumHeight(600)
         horiz_splitter.addWidget(plumb_widget)
 

--- a/application/application.py
+++ b/application/application.py
@@ -77,11 +77,15 @@ class Application:
         horiz_splitter.setChildrenCollapsible(False)
 
         daq_widget = DAQLayout()
+
         self.daq_bridge.channelAdded.connect(daq_widget.addChannel)
         self.daq_bridge.channelRemoved.connect(daq_widget.removeChannel)
         self.daq_bridge.dataUpdated.connect(daq_widget.updateData)
-        daq_widget.channelSelected.connect(self.daq_bridge.addChannel)
-        daq_widget.channelDeselected.connect(self.daq_bridge.removeChannel)
+
+        self.plumbing_bridge.engineLoaded.connect(daq_widget.channel_selector.updateNodeList)
+        daq_widget.channel_selector.channelSelected.connect(self.daq_bridge.addChannel)
+        daq_widget.channel_selector.channelDeselected.connect(self.daq_bridge.removeChannel)
+
         horiz_splitter.addWidget(daq_widget)
 
         plumb_widget = make_qml_widget(self.qml_engine, 'PlumbingPane.qml')

--- a/application/application.py
+++ b/application/application.py
@@ -58,14 +58,6 @@ class Application:
 
         self.main_window = self._make_main_window()
 
-        self.daq_bridge.addChannel('A')
-        self.daq_bridge.addChannel('B')
-        self.daq_bridge.addChannel('C')
-        # self.daq_bridge.addChannel('D')
-        # self.daq_bridge.addChannel('E')
-        # self.daq_bridge.addChannel('F')
-        # self.daq_bridge.addChannel('G')
-
         # TODO(jacob): Currently we load these example files at startup
         # to make testing turnaround a bit faster. Figure out how to
         # make the application remember the last file opened, and open
@@ -88,6 +80,8 @@ class Application:
         self.daq_bridge.channelAdded.connect(daq_widget.addChannel)
         self.daq_bridge.channelRemoved.connect(daq_widget.removeChannel)
         self.daq_bridge.dataUpdated.connect(daq_widget.updateData)
+        daq_widget.channelSelected.connect(self.daq_bridge.addChannel)
+        daq_widget.channelDeselected.connect(self.daq_bridge.removeChannel)
         horiz_splitter.addWidget(daq_widget)
 
         plumb_widget = make_qml_widget(self.qml_engine, 'PlumbingPane.qml')

--- a/application/daq.py
+++ b/application/daq.py
@@ -38,7 +38,7 @@ def trim_earlier(array, t):
 class DAQBridge(QObject):
     channelAdded = Signal(str)
     channelRemoved = Signal(str)
-    dataUpdated = Signal(str, list, list)  # channel name, time vals, data vals
+    dataUpdated = Signal(str, np.ndarray, np.ndarray)  # channel name, time vals, data vals
 
     def __init__(self, plumbing_bridge):
         QObject.__init__(self)
@@ -60,7 +60,7 @@ class DAQBridge(QObject):
         del self.data_values[channel_name]
         self.channelRemoved.emit(channel_name)
 
-    @Slot(dict, list)
+    @Slot(dict, np.ndarray)
     def update(self, datapoints, times):
         """
         Update the tracked data channels with new data.
@@ -119,21 +119,21 @@ class DAQLayout(QWidget):
         self.graphs.ci.setBorder('w', width=2)
         self.layout().addWidget(self.graphs)
 
-        self.control_layout = QVBoxLayout()
-        control_widget = QWidget()
-        control_widget.setLayout(self.control_layout)
-        self.layout().addWidget(control_widget)
+        # self.control_layout = QVBoxLayout()
+        # control_widget = QWidget()
+        # control_widget.setLayout(self.control_layout)
+        # self.layout().addWidget(control_widget)
 
-        self.control_group = QButtonGroup()
-        self.control_group.setExclusive(False)
-        self.control_group.idToggled.connect(self.checkboxChecked)
-        self.ids_to_channels = {}
+        # self.control_group = QButtonGroup()
+        # self.control_group.setExclusive(False)
+        # self.control_group.idToggled.connect(self.checkboxChecked)
+        # self.ids_to_channels = {}
 
-        for i, channel in enumerate(['A', 'B', 'C', 'D']):
-            checkbox = QCheckBox(channel)
-            self.control_group.addButton(checkbox, i)
-            self.control_layout.addWidget(checkbox)
-            self.ids_to_channels[i] = channel
+        # for i, channel in enumerate(['A', 'B', 'C', 'D']):
+        #     checkbox = QCheckBox(channel)
+        #     self.control_group.addButton(checkbox, i)
+        #     self.control_layout.addWidget(checkbox)
+        #     self.ids_to_channels[i] = channel
 
     @Slot(int)
     def checkboxChecked(self, checkbox_id, is_checked):
@@ -161,7 +161,7 @@ class DAQLayout(QWidget):
         del self.plots[channel_name]
         del self.rows[channel_name]
 
-    @Slot(str, list, list)
+    @Slot(str, np.ndarray, np.ndarray)
     def updateData(self, channel_name, times, data_vals):
         plot = self.plots[channel_name]
         plot.setData(times, data_vals)

--- a/application/daq.py
+++ b/application/daq.py
@@ -87,6 +87,12 @@ class DAQBridge(QObject):
         if len(times) == 0:
             return
 
+        if len(self.times) > 0 and top.micros_to_s(times[0]) < self.times[-1]:
+            # We stepped back in time, clear all existing time values.
+            # We don't need to clear data_values since they'll
+            # automatically be trimmed to the relevant data later on.
+            self.times = np.array([])
+
         trim_time = top.micros_to_s(times[-1]) - self.window_size_s
         appended = np.append(self.times, top.micros_to_s(times))
         self.times = trim_earlier(appended, trim_time)

--- a/application/daq.py
+++ b/application/daq.py
@@ -111,6 +111,7 @@ class DAQPlotWidget(pg.GraphicsLayoutWidget):
             return
         new_row_num = len(self.rows)
         plot = self.addPlot(row=new_row_num, col=0)
+        plot.setLimits(minYRange=1)
         self.plots[channel_name] = plot.plot()
         self.rows[channel_name] = new_row_num
 

--- a/application/daq.py
+++ b/application/daq.py
@@ -1,0 +1,126 @@
+import warnings
+
+from PySide2.QtCore import Qt, QObject, Slot, Signal, Property
+import pyqtgraph as pg
+import numpy as np
+
+import topside as top
+
+
+def trim_earlier(array, t):
+    """
+    Return the portion of an array falling after a reference value.
+
+    Parameters
+    ----------
+
+    array: list or numpy.ndarray
+        The array to trim. Must be monotonically increasing.
+
+    t: number
+        The reference value used for trimming the array.
+
+    Returns an array corresponding to the portion of `array` after the
+    first value greater than or equal to `t`.
+
+    For example:
+        trim_earlier([1, 3, 5], 2) == [3, 5]
+        trim_earlier([4, 6, 8], 6) == [6, 8]
+        trim_earlier([10, 20, 30], 40) == []
+    """
+    i = 0
+    while i < len(array) and array[i] < t:
+        i += 1
+    return array[i:]
+
+
+class DAQBridge(QObject):
+    channelAdded = Signal(str)
+    channelRemoved = Signal(str)
+    dataUpdated = Signal(str, list, list)  # channel name, time vals, data vals
+
+    def __init__(self, plumbing_bridge):
+        QObject.__init__(self)
+        plumbing_bridge.dataUpdated.connect(self.update)
+        self.data_values = {}
+        self.times = np.array([])
+        self.window_size_s = 10  # TODO(jacob): Add a UI field for this.
+
+    @Slot(str)
+    def addChannel(self, channel_name):
+        if channel_name in self.data_values:
+            warnings.warn('attempted to add a duplicate channel to DAQ')
+            return
+        self.data_values[channel_name] = np.array([])
+        self.channelAdded.emit(channel_name)
+
+    @Slot(str)
+    def removeChannel(self, channel_name):
+        del self.data_values[channel_name]
+        self.channelRemoved.emit(channel_name)
+
+    @Slot(dict, list)
+    def update(self, datapoints, times):
+        """
+        Update the tracked data channels with new data.
+
+        This function will automatically trim the existing data to
+        remain within the window size. For example, if the window size
+        is 10s, we have data from 12s to 22s, and we get new data from
+        22s to 25s, we will end up with data from 15s to 25s after
+        calling `update`.
+
+        Parameters
+        ----------
+
+        datapoints: dict
+            `datapoints` is a dict of the form `{channel: values}`,
+            where `channel` is a string corresponding to a tracked
+            channel name and `values` is a list of new data values.
+
+        times: list
+            `times` is a list of the form `[t1, t2, t3]`. It is expected
+            to be the same length as each `values` list. For any channel
+            in `datapoints`, `values[i]` is the value of the channel at
+            time `times[i]`.
+        """
+        if len(times) == 0:
+            return
+
+        trim_time = top.micros_to_s(times[-1]) - self.window_size_s
+        appended = np.append(self.times, top.micros_to_s(times))
+        self.times = trim_earlier(appended, trim_time)
+
+        for channel, values in datapoints.items():
+            if channel in self.data_values:
+                extended = np.append(self.data_values[channel], values)
+                self.data_values[channel] = extended[-len(self.times):]
+                self.dataUpdated.emit(channel, self.times, self.data_values[channel])
+
+
+class DAQPlotWidget(pg.GraphicsLayoutWidget):
+    def __init__(self, parent=None):
+        pg.GraphicsLayoutWidget.__init__(self, parent)
+        self.plots = {}
+        self.rows = {}
+
+    @Slot(str)
+    def addChannel(self, channel_name):
+        if channel_name in self.plots:
+            warnings.warn('attempted to add a duplicate channel to DAQ')
+            return
+        new_row_num = len(self.rows)
+        plot = self.addPlot(row=new_row_num, col=0)
+        self.plots[channel_name] = plot.plot()
+        self.rows[channel_name] = new_row_num
+
+    @Slot(str)
+    def removeChannel(self, channel_name):
+        self.removeItem(self.rows[channel_name], 0)
+        del self.plots[channel_name]
+        del self.rows[channel_name]
+
+    @Slot(str, list, list)
+    def updateData(self, channel_name, times, data_vals):
+        plot = self.plots[channel_name]
+        plot.setData(times, data_vals)

--- a/application/daq.py
+++ b/application/daq.py
@@ -137,7 +137,6 @@ class DAQLayout(QWidget):
         self.channel_selector = ChannelSelector()
         self.layout().addWidget(self.channel_selector)
 
-
     @Slot(str)
     def addChannel(self, channel_name):
         if channel_name in self.plot_items:

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -1,17 +1,19 @@
 from PySide2.QtCore import QObject, Signal, Slot
 from PySide2.QtWidgets import QFileDialog
+import numpy as np
 
 import topside as top
 
 
 class PlumbingBridge(QObject):
     engineLoaded = Signal(top.PlumbingEngine)
-    dataUpdated = Signal()
+    dataUpdated = Signal(dict, list)
 
     def __init__(self):
         QObject.__init__(self)
 
         self.engine = None
+        self.step_size = 0.1e6  # TODO(jacob): Add a UI field for this.
 
     def load_engine(self, new_engine):
         self.engine = new_engine
@@ -56,11 +58,23 @@ class PlumbingBridge(QObject):
 
     @Slot()
     def timeStepForward(self):
-        step_size = 0.1e6  # TODO(jacob): Add a UI field for this.
-        self.engine.step(step_size)
-        self.dataUpdated.emit()
+        pressures = self.engine.step(self.step_size)
+        self.dataUpdated.emit(pressures, np.array([self.engine.time]))
 
     @Slot()
     def timeAdvance(self):
-        self.engine.solve()
-        self.dataUpdated.emit()
+        initial_time = self.engine.time
+        states = self.engine.solve(return_resolution=self.step_size)
+
+        # TODO(jacob/wendi): Change the data format returned by
+        # PlumbingEngine.solve so we don't need to rearrange the data on
+        # this side.
+        pressures = {node: [] for node in states[0]}
+        for state in states:
+            for node, pressure in state.items():
+                pressures[node].append(pressure)
+        pressures_np = {node: np.array(pvals) for node, pvals in pressures.items()}
+
+        times = np.arange(len(states)) * self.step_size + initial_time + self.step_size
+
+        self.dataUpdated.emit(pressures_np, times)

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -56,7 +56,7 @@ class PlumbingBridge(QObject):
     def timeStop(self):
         self.timer.stop()
         self.engine.reset()
-        self.dataUpdated.emit()
+        self.dataUpdated.emit(self.engine.current_pressures(), np.array([self.engine.time]))
 
     @Slot()
     def timeStepForward(self):

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal, Slot, QTimer
+from PySide2.QtCore import Qt, QObject, Signal, Slot, QTimer
 from PySide2.QtWidgets import QFileDialog
 import numpy as np
 
@@ -13,8 +13,9 @@ class PlumbingBridge(QObject):
         QObject.__init__(self)
 
         self.engine = None
-        self.step_size = 0.1e6  # TODO(jacob): Add a UI field for this.
+        self.step_size = 0.05e6  # TODO(jacob): Add a UI field for this.
         self.timer = QTimer()
+        self.timer.setTimerType(Qt.PreciseTimer)
         self.timer.timeout.connect(self.timeStepForward)
 
     def load_engine(self, new_engine):

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal, Slot
+from PySide2.QtCore import QObject, Signal, Slot, QTimer
 from PySide2.QtWidgets import QFileDialog
 import numpy as np
 
@@ -14,6 +14,8 @@ class PlumbingBridge(QObject):
 
         self.engine = None
         self.step_size = 0.1e6  # TODO(jacob): Add a UI field for this.
+        self.timer = QTimer()
+        self.timer.timeout.connect(self.timeStepForward)
 
     def load_engine(self, new_engine):
         self.engine = new_engine
@@ -44,15 +46,15 @@ class PlumbingBridge(QObject):
 
     @Slot()
     def timePlay(self):
-        # TODO(jacob): Implement real-time simulation.
-        pass
+        self.timer.start(50)
 
     @Slot()
     def timePause(self):
-        pass
+        self.timer.stop()
 
     @Slot()
     def timeStop(self):
+        self.timer.stop()
         self.engine.reset()
         self.dataUpdated.emit()
 

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -7,7 +7,7 @@ import topside as top
 
 class PlumbingBridge(QObject):
     engineLoaded = Signal(top.PlumbingEngine)
-    dataUpdated = Signal(dict, list)
+    dataUpdated = Signal(dict, np.ndarray)
 
     def __init__(self):
         QObject.__init__(self)

--- a/application/plumbing_bridge.py
+++ b/application/plumbing_bridge.py
@@ -23,6 +23,7 @@ class PlumbingBridge(QObject):
     def load_engine(self, new_engine):
         self.engine = new_engine
         self.engineLoaded.emit(new_engine)
+        self.timeStop()
 
     def load_from_files(self, filepaths):
         parser = top.pdl.Parser(filepaths)

--- a/application/resources/DAQPane.qml
+++ b/application/resources/DAQPane.qml
@@ -1,4 +1,0 @@
-import QtQuick 2.0
-
-Rectangle {
-}

--- a/application/resources/PlumbingPane.qml
+++ b/application/resources/PlumbingPane.qml
@@ -79,16 +79,15 @@ ColumnLayout {
                 Layout.preferredHeight: 50
                 Layout.preferredWidth: 50
                 icon.color: "transparent"
-                property bool is_play: true
-                icon.source: is_play ? "themes/default/play.png" : "themes/default/pause.png"
+                icon.source: plumbingBridge.paused ?
+                    "themes/default/play.png" : "themes/default/pause.png"
 
                 onClicked: {
-                    if (is_play) {
+                    if (plumbingBridge.paused) {
                         plumbingBridge.timePlay()
                     } else {
                         plumbingBridge.timePause()
                     }
-                    is_play = !is_play
                 }
             }
             Button {

--- a/application/tests/test_application.py
+++ b/application/tests/test_application.py
@@ -1,8 +1,8 @@
 from ..application import Application
 
 
-def test_application_init():
-    # TODO(jacob): Investigate if there's any way to spoof GUI events
-    # for controls defined in QML and test GUI interactions.
-    app = Application([])
-    app.shutdown()
+# def test_application_init():
+#     # TODO(jacob): Investigate if there's any way to spoof GUI events
+#     # for controls defined in QML and test GUI interactions.
+#     app = Application([])
+#     app.shutdown()

--- a/application/tests/test_application.py
+++ b/application/tests/test_application.py
@@ -1,8 +1,8 @@
 from ..application import Application
 
 
-# def test_application_init():
-#     # TODO(jacob): Investigate if there's any way to spoof GUI events
-#     # for controls defined in QML and test GUI interactions.
-#     app = Application([])
-#     app.shutdown()
+def test_application_init():
+    # TODO(jacob): Investigate if there's any way to spoof GUI events
+    # for controls defined in QML and test GUI interactions.
+    app = Application([])
+    app.shutdown()

--- a/application/tests/test_daq.py
+++ b/application/tests/test_daq.py
@@ -64,3 +64,24 @@ def test_daq_model_update_rollover():
     assert_equal(m.times, [10, 15, 20])
     assert_equal(m.data_values['p1'], [11, 12, 13])
     assert_equal(m.data_values['p2'], [21, 22, 23])
+
+
+def test_daq_model_update_earlier_time():
+    m = DAQBridge(MockPlumbingBridge())
+
+    m.addChannel('p1')
+    m.addChannel('p2')
+
+    m.update({
+        'p1': np.array([10, 11, 12, 13]),
+        'p2': np.array([20, 21, 22, 23])
+    }, np.array([10e6, 11e6, 12e6, 13e6]))
+
+    m.update({
+        'p1': np.array([14, 15, 16, 17]),
+        'p2': np.array([24, 25, 26, 27])
+    }, np.array([5e6, 6e6, 7e6, 8e6]))
+
+    assert_equal(m.times, [5, 6, 7, 8])
+    assert_equal(m.data_values['p1'], [14, 15, 16, 17])
+    assert_equal(m.data_values['p2'], [24, 25, 26, 27])

--- a/application/tests/test_daq.py
+++ b/application/tests/test_daq.py
@@ -2,11 +2,14 @@ from PySide2.QtCore import QObject, Signal
 import numpy as np
 from numpy.testing import assert_equal
 
+import topside as top
 from ..daq import trim_earlier, DAQBridge
+from ..plumbing_bridge import PlumbingBridge
 
 
 class MockPlumbingBridge(QObject):
     dataUpdated = Signal(dict, int)
+    engineLoaded = Signal(top.PlumbingEngine)
 
     def __init__(self):
         QObject.__init__(self)

--- a/application/tests/test_daq.py
+++ b/application/tests/test_daq.py
@@ -1,0 +1,66 @@
+from PySide2.QtCore import QObject, Signal
+import numpy as np
+from numpy.testing import assert_equal
+
+from ..daq import trim_earlier, DAQBridge
+
+
+class MockPlumbingBridge(QObject):
+    dataUpdated = Signal(dict, int)
+
+    def __init__(self):
+        QObject.__init__(self)
+
+
+def test_trim_earlier():
+    arr = np.array([1, 2, 3, 4, 5])
+
+    assert_equal(trim_earlier(arr, 2.5), [3, 4, 5])
+    assert_equal(trim_earlier(arr, 4), [4, 5])
+    assert_equal(trim_earlier(arr, 6), [])
+
+    assert_equal(trim_earlier(np.array([]), 10), [])
+
+
+def test_daq_bridge_add_remove():
+    m = DAQBridge(MockPlumbingBridge())
+
+    m.addChannel('p1')
+    m.addChannel('p2')
+    m.removeChannel('p1')
+
+    assert 'p1' not in m.data_values
+    assert_equal(m.data_values['p2'], [])
+
+
+def test_daq_model_update():
+    m = DAQBridge(MockPlumbingBridge())
+
+    m.addChannel('p1')
+    m.addChannel('p2')
+
+    m.update({
+        'p1': np.array([10, 11]),
+        'p2': np.array([20, 21]),
+        'p3': np.array([30, 31])  # should be ignored
+    }, np.array([5e6, 6e6]))
+
+    assert_equal(m.times, [5, 6])
+    assert_equal(m.data_values['p1'], [10, 11])
+    assert_equal(m.data_values['p2'], [20, 21])
+
+
+def test_daq_model_update_rollover():
+    m = DAQBridge(MockPlumbingBridge())
+
+    m.addChannel('p1')
+    m.addChannel('p2')
+
+    m.update({
+        'p1': np.array([10, 11, 12, 13]),
+        'p2': np.array([20, 21, 22, 23])
+    }, np.array([5e6, 10e6, 15e6, 20e6]))
+
+    assert_equal(m.times, [10, 15, 20])
+    assert_equal(m.data_values['p1'], [11, 12, 13])
+    assert_equal(m.data_values['p2'], [21, 22, 23])

--- a/application/tests/test_plumb_daq_integration.py
+++ b/application/tests/test_plumb_daq_integration.py
@@ -1,0 +1,56 @@
+import copy
+
+from numpy.testing import assert_equal
+
+import topside as top
+from ..daq import DAQBridge
+from ..plumbing_bridge import PlumbingBridge
+
+
+class MockPlumbingEngine:
+    def __init__(self):
+        self.time = 0
+        self.pressures = {'n1': 0, 'n2': 0}
+
+    def step(self, step_size):
+        self.time += step_size
+        for node in self.pressures:
+            self.pressures[node] += 1
+        return copy.deepcopy(self.pressures)
+
+    def solve(self, return_resolution):
+        states = []
+        for i in range(5):
+            states.append(self.step(return_resolution))
+        return states
+
+
+def test_step_forward():
+    plumb = PlumbingBridge()
+    plumb.engine = MockPlumbingEngine()
+    daq = DAQBridge(plumb)
+    daq.addChannel('n1')
+    daq.addChannel('n2')
+
+    plumb.timeStepForward()
+
+    assert_equal(daq.times, [0.1])
+    assert_equal(daq.data_values, {'n1': [1], 'n2': [1]})
+
+    plumb.timeStepForward()
+
+    assert_equal(daq.times, [0.1, 0.2])
+    assert_equal(daq.data_values, {'n1': [1, 2], 'n2': [1, 2]})
+
+
+def test_advance():
+    plumb = PlumbingBridge()
+    plumb.engine = MockPlumbingEngine()
+    daq = DAQBridge(plumb)
+    daq.addChannel('n1')
+    daq.addChannel('n2')
+
+    plumb.timeAdvance()
+
+    assert_equal(daq.times, [0.1, 0.2, 0.3, 0.4, 0.5])
+    assert_equal(daq.data_values, {'n1': [1, 2, 3, 4, 5], 'n2': [1, 2, 3, 4, 5]})

--- a/application/tests/test_plumb_daq_integration.py
+++ b/application/tests/test_plumb_daq_integration.py
@@ -47,6 +47,7 @@ class MockPlotter(QObject):
 
 def test_step_forward():
     plumb = PlumbingBridge()
+    plumb.step_size = 0.1e6
     plumb.engine = MockPlumbingEngine()
     daq = DAQBridge(plumb)
     plotter = MockPlotter(daq)
@@ -67,6 +68,7 @@ def test_step_forward():
 
 def test_track_new_channel():
     plumb = PlumbingBridge()
+    plumb.step_size = 0.1e6
     plumb.engine = MockPlumbingEngine()
     daq = DAQBridge(plumb)
     plotter = MockPlotter(daq)
@@ -85,6 +87,7 @@ def test_track_new_channel():
 
 def test_advance():
     plumb = PlumbingBridge()
+    plumb.step_size = 0.1e6
     plumb.engine = MockPlumbingEngine()
     daq = DAQBridge(plumb)
     plotter = MockPlotter(daq)
@@ -102,6 +105,7 @@ def test_advance():
 
 def test_stop():
     plumb = PlumbingBridge()
+    plumb.step_size = 0.1e6
     plumb.engine = MockPlumbingEngine()
     daq = DAQBridge(plumb)
     plotter = MockPlotter(daq)

--- a/application/tests/test_plumb_daq_integration.py
+++ b/application/tests/test_plumb_daq_integration.py
@@ -12,6 +12,9 @@ class MockPlumbingEngine:
         self.time = 0
         self.pressures = {'n1': 0, 'n2': 0}
 
+    def current_pressures(self):
+        return self.pressures
+
     def step(self, step_size):
         self.time += step_size
         for node in self.pressures:
@@ -23,6 +26,10 @@ class MockPlumbingEngine:
         for i in range(5):
             states.append(self.step(return_resolution))
         return states
+
+    def reset(self):
+        self.time = 0
+        self.pressures = {node: 0 for node in self.pressures}
 
 
 def test_step_forward():
@@ -54,3 +61,23 @@ def test_advance():
 
     assert_equal(daq.times, [0.1, 0.2, 0.3, 0.4, 0.5])
     assert_equal(daq.data_values, {'n1': [1, 2, 3, 4, 5], 'n2': [1, 2, 3, 4, 5]})
+
+
+def test_stop():
+    plumb = PlumbingBridge()
+    plumb.engine = MockPlumbingEngine()
+    daq = DAQBridge(plumb)
+    daq.addChannel('n1')
+    daq.addChannel('n2')
+
+    plumb.timeStepForward()
+    plumb.timeStepForward()
+    plumb.timeStepForward()
+
+    assert_equal(daq.times, [0.1, 0.2, 0.3])
+    assert_equal(daq.data_values, {'n1': [1, 2, 3], 'n2': [1, 2, 3]})
+
+    plumb.timeStop()
+
+    assert_equal(daq.times, [0])
+    assert_equal(daq.data_values, {'n1': [0], 'n2': [0]})

--- a/application/tests/test_proc_plumb_integration.py
+++ b/application/tests/test_proc_plumb_integration.py
@@ -65,6 +65,7 @@ def test_proc_bridge_procedure_step_affects_plumbing():
 
 def test_time_step_forward():
     plumb_b = PlumbingBridge()
+    plumb_b.step_size = 0.1e6
     proc_b = ProceduresBridge(plumb_b)
 
     procedure = top.Procedure('main', [
@@ -143,6 +144,7 @@ def test_time_advance():
 
 def test_time_stop():
     plumb_b = PlumbingBridge()
+    plumb_b.step_size = 0.1e6
     proc_b = ProceduresBridge(plumb_b)
 
     procedure = top.Procedure('main', [

--- a/application/visualization_area.py
+++ b/application/visualization_area.py
@@ -314,6 +314,7 @@ class VisualizationArea(QQuickPaintedItem):
         self.engine_instance = engine
         self.terminal_graph = top.terminal_graph(self.engine_instance)
         self.layout_pos = top.layout_plumbing_engine(self.engine_instance)
+        self.setRescaleNeeded()
         self.update()
 
     @Slot()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib==3.3.0
 networkx==2.4
 numpy==1.19.2
 pyinstaller==4.1
+pyqtgraph==0.11.0
 PySide2==5.15.1
 pytest==5.4.2
 pyyaml==5.3.1

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -68,7 +68,7 @@ class ProceduresEngine:
         """
         Update all current conditions by querying the managed plumbing engine.
         """
-        if self._plumb is not None:
+        if self._plumb is not None and self.current_step is not None:
             time = self._plumb.time
             pressures = self._plumb.current_pressures()
             state = {'time': time, 'pressures': pressures}


### PR DESCRIPTION
Stacked on top of #105. Also depends on #106, but not stacked because I didn't want Git to get confusing.

This PR introduces two key features:
- A functional DAQ pane with graphs for potentially every node in the plumbing engine, along with a menu to select which nodes should be graphed
- Real-time simulation: click the "Play" button underneath the P&ID to start the flow of time. Currently time will run at 1 s/s, but we should be able to configure this fairly easily in the future.

The new features should play nicely with everything else present in the application (loading new files, resetting the procedures and plumbing engines), but let me know if you find a weird interaction.

Known issues:
- #107 (not a bug with this PR, just one that's easier to see when we have graphs)
- Clicking "Play" and then stopping time with "Stop" will not reset the play button back to play (it will leave it as "Pause"). Fix coming tomorrow, probably.

I also want to do a bit of cleanup on `Application._make_main_window` before merging.

![image](https://user-images.githubusercontent.com/13474696/99939443-0a59ae00-2d38-11eb-89cf-60572630c4d8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/108)
<!-- Reviewable:end -->
