### PR TITLE
proc: Introduce pre- and post-nodes

### DIFF
--- a/application/procedures_bridge.py
+++ b/application/procedures_bridge.py
@@ -8,6 +8,7 @@ from .procedure_wrappers import ProcedureStepsModel
 class ProceduresBridge(QObject):
     goto_step_sig = Signal(int, name='gotoStep')
     steps_changed_sig = Signal(name='dataChanged')
+    position_changed_sig = Signal(name='positionChanged')
 
     def __init__(self, plumb):
         QObject.__init__(self)
@@ -33,6 +34,8 @@ class ProceduresBridge(QObject):
         idx = proc.index_of(self._proc_eng.current_step.step_id)
         self.goto_step_sig.emit(idx)
 
+        self.position_changed_sig.emit()
+
         self._proc_steps.refresh(idx)
 
     def load_suite(self, suite):
@@ -48,6 +51,12 @@ class ProceduresBridge(QObject):
     @Property(QObject, notify=steps_changed_sig)
     def steps(self):
         return self._proc_steps
+
+    @Property(str, notify=position_changed_sig)
+    def stepPosition(self):
+        if self._proc_eng.step_position is None:
+            return ''
+        return self._proc_eng.step_position.name
 
     @Slot()
     def loadFromDialog(self):

--- a/application/resources/ProceduresPane.qml
+++ b/application/resources/ProceduresPane.qml
@@ -70,17 +70,26 @@ ColumnLayout {
         id: procedureStepDelegate
 
         Rectangle {
-            property string stepHighlightBg: "#d8fff7"
+            property bool inPostNode: proceduresBridge.stepPosition == 'After'
+
+            property string stepHighlightBgPre: "#d8fff7"
+            property string stepHighlightBgPost: "#ebd35b"
             property string stepHighlightBorder: "#800000"
+
             property string stepEvenIdxBg: "#f2f2f2"
             property string stepOddIdxBg: "#f9f9f9"
+            property string stepInactiveBorder: "transparent"
+
             property string stepOperatorTxt: "#002060"
+
+            property string stepHighlightBg: inPostNode ? stepHighlightBgPre : stepHighlightBgPost
+            property string stepInactiveBg: index % 2 == 0 ? stepEvenIdxBg : stepOddIdxBg
 
             id: wrapper
             width: proceduresList.width
             height: procedureColumn.height + 10
-            color: ListView.isCurrentItem ? stepHighlightBg : (index % 2 == 0 ? stepEvenIdxBg : stepOddIdxBg)
-            border.color: ListView.isCurrentItem ? stepHighlightBorder : "transparent"
+            color: ListView.isCurrentItem ? stepHighlightBg : stepInactiveBg
+            border.color: ListView.isCurrentItem ? stepHighlightBorder : stepInactiveBorder
 
             Column {
                 id: procedureColumn
@@ -122,8 +131,10 @@ ColumnLayout {
                 // TODO(jacob): Do we really need a Loader here, or can we just insert the Repeater
                 // directly?
                 Loader {
-                    visible: wrapper.ListView.isCurrentItem
-                    sourceComponent: wrapper.ListView.isCurrentItem ? stepConditionsDelegate : null
+                    property bool isActive: wrapper.ListView.isCurrentItem && inPostNode
+
+                    visible: isActive
+                    sourceComponent: isActive ? stepConditionsDelegate : null
                     onStatusChanged: if (status == Loader.Ready) item.model = conditions
                 }
             }

--- a/application/resources/example.proc
+++ b/application/resources/example.proc
@@ -1,9 +1,8 @@
 main:
-    1. PRIMARY: set SC_001 to closed
-    2. PRIMARY: set SC_001 to open
-    3. CONTROL: set O_MV_2 to open
-    4. CONTROL: set O_MV_1 to open
-    5. CONTROL: [D > 400] set O_MV_1 to closed
-    6. CONTROL: set O_MV_2 to closed
-    7. PRIMARY: set BA_005 to open
-    8. CONTROL: set O_MV_3 to open
+    1. PRIMARY: set SC_001 to open
+    2. CONTROL: set O_MV_2 to open
+    3. CONTROL: set O_MV_1 to open
+    4. CONTROL: [D > 400] set O_MV_1 to closed
+    5. CONTROL: set O_MV_2 to closed
+    6. PRIMARY: set BA_005 to open
+    7. CONTROL: set O_MV_3 to open

--- a/application/tests/test_proc_plumb_integration.py
+++ b/application/tests/test_proc_plumb_integration.py
@@ -80,7 +80,7 @@ def test_time_step_forward():
 
     proc_eng = proc_b._proc_eng
 
-    proc_b.procStepForward()  # advance to step 1
+    proc_b.procStepForward()  # execute step 1
     assert not proc_eng.ready_to_proceed()
     # Time hasn't advanced yet, so pressures should be the same
     assert plumb_eng.current_pressures('A') == 100
@@ -96,7 +96,7 @@ def test_time_step_forward():
     assert proc_eng.ready_to_proceed()
     pressures_at_02 = plumb_eng.current_pressures()
 
-    proc_b.procStepForward()  # advance to step 2
+    proc_b.procStepForward()  # execute step 2
     assert not proc_eng.ready_to_proceed()
     assert plumb_eng.current_pressures() == pressures_at_02
 
@@ -124,7 +124,7 @@ def test_time_advance():
 
     proc_eng = proc_b._proc_eng
 
-    proc_b.procStepForward()  # advance to step 1
+    proc_b.procStepForward()  # execute step 1
     assert not proc_eng.ready_to_proceed()
     assert plumb_eng.current_pressures('A') == 100
     assert plumb_eng.current_pressures('B') == 0
@@ -153,7 +153,7 @@ def test_time_stop():
 
     proc_eng = proc_b._proc_eng
 
-    proc_b.procStepForward()  # advance to step 1
+    proc_b.procStepForward()  # execute step 1
     assert not proc_eng.ready_to_proceed()
     # Time hasn't advanced yet, so pressures should be the same
     assert plumb_eng.current_pressures('A') == 100

--- a/application/tests/test_procedures_bridge.py
+++ b/application/tests/test_procedures_bridge.py
@@ -56,9 +56,16 @@ def test_proc_bridge_procedure_controls_advance_procedure():
     proc_eng = proc_b._proc_eng
 
     assert proc_eng.current_step == procedure.step_list[0]
+    assert proc_eng.step_position == top.StepPosition.Before
+    proc_b.procStepForward()
+    assert proc_eng.current_step == procedure.step_list[0]
+    assert proc_eng.step_position == top.StepPosition.After
     proc_b.procStepForward()
     assert proc_eng.current_step == procedure.step_list[1]
+    assert proc_eng.step_position == top.StepPosition.After
     proc_b.procStepForward()  # does nothing; condition is not satisfied
     assert proc_eng.current_step == procedure.step_list[1]
+    assert proc_eng.step_position == top.StepPosition.After
     proc_b.procStop()
     assert proc_eng.current_step == procedure.step_list[0]
+    assert proc_eng.step_position == top.StepPosition.Before

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -102,7 +102,9 @@ class ProceduresEngine:
         """
         Evaluate if the engine is ready to proceed to a next step.
 
-        Returns True if any condition is satisfied, and False otherwise.
+        Returns False if the engine is in a pre-node, since 'proceed' is
+        only valid from a post-node. If in a post-node, returns True if
+        any condition is satisfied and False otherwise.
         """
         if self.current_step is None or self.step_position == StepPosition.Before:
             return False

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -45,10 +45,6 @@ class ProceduresEngine:
 
         Does NOT affect the managed plumbing engine.
         """
-        # TODO(jacob): When we load a new procedure, we start in the
-        # first step, but that means that the action for that step never
-        # gets executed (we just start waiting on its conditions
-        # immediately). Figure out an elegant way to resolve this.
         if self._suite is not None:
             self.current_procedure_id = self._suite.starting_procedure_id
             self.current_step = self._suite[self.current_procedure_id].step_list[0]

--- a/topside/procedures/tests/run_simulation.py
+++ b/topside/procedures/tests/run_simulation.py
@@ -54,7 +54,7 @@ procedures_eng = top.ProceduresEngine(plumb, suite)
 all_pressure = []
 
 while len(procedures_eng.current_step.conditions) > 0 and plumb.time < top.s_to_micros(args.max_time):
-    if procedures_eng.ready_to_advance():
+    if procedures_eng.ready_to_proceed():
         procedures_eng.next_step()
     procedures_eng.step_time()
     all_pressure.append(plumb.current_pressures())


### PR DESCRIPTION
Distinguish between being "after" a step from being "before" the
subsequent procedure step. This allows the procedures engine to
correctly execute the first step in a procedure.

Right now, the "procedure step forward" button in the application
executes `next_step`, which advances the procedures engine to the
next post-node. There might be a more intuitive behaviour, but we
can do testing on that later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/112)
<!-- Reviewable:end -->
