### PR TITLE
proc: Change WaitUntil condition to WaitFor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,4 @@ omit =
 exclude_lines =
     pragma: no cover
     if self.DEBUG_MODE:
+    raise NotImplementedError

--- a/application/tests/test_proc_plumb_integration.py
+++ b/application/tests/test_proc_plumb_integration.py
@@ -68,9 +68,9 @@ def test_time_step_forward():
 
     procedure = top.Procedure('main', [
         top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-            (top.WaitUntil(0.2e6), top.Transition('main', '2'))], 'PRIMARY'),
+            (top.WaitFor(0.2e6), top.Transition('main', '2'))], 'PRIMARY'),
         top.ProcedureStep('2', top.StateChangeAction('injector_valve', 'closed'), [
-            (top.WaitUntil(0.4e6), top.Transition('main', '3'))], 'PRIMARY'),
+            (top.WaitFor(0.4e6), top.Transition('main', '3'))], 'PRIMARY'),
         top.ProcedureStep('3', top.MiscAction('Approach the launch tower'), [], 'SECONDARY')
     ])
     proc_b.load_suite(top.ProcedureSuite([procedure]))
@@ -143,7 +143,7 @@ def test_time_stop():
 
     procedure = top.Procedure('main', [
         top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-            (top.WaitUntil(0.1e6), top.Transition('main', '2'))], 'PRIMARY'),
+            (top.WaitFor(0.1e6), top.Transition('main', '2'))], 'PRIMARY'),
         top.ProcedureStep('2', top.MiscAction('Approach the launch tower'), [], 'SECONDARY')
     ])
     proc_b.load_suite(top.ProcedureSuite([procedure]))

--- a/application/tests/test_proc_plumb_integration.py
+++ b/application/tests/test_proc_plumb_integration.py
@@ -70,7 +70,7 @@ def test_time_step_forward():
         top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
             (top.WaitFor(0.2e6), top.Transition('main', '2'))], 'PRIMARY'),
         top.ProcedureStep('2', top.StateChangeAction('injector_valve', 'closed'), [
-            (top.WaitFor(0.4e6), top.Transition('main', '3'))], 'PRIMARY'),
+            (top.WaitFor(0.2e6), top.Transition('main', '3'))], 'PRIMARY'),
         top.ProcedureStep('3', top.MiscAction('Approach the launch tower'), [], 'SECONDARY')
     ])
     proc_b.load_suite(top.ProcedureSuite([procedure]))

--- a/application/tests/test_procedure_wrappers.py
+++ b/application/tests/test_procedure_wrappers.py
@@ -4,11 +4,11 @@ from ..procedure_wrappers import ProcedureStepsModel, ProcedureConditionWrapper
 
 def test_condition_wrapper_wraps_condition():
     cond = top.WaitFor(1)
+    cond.reinitialize({'time': 0})
 
     wrapper = ProcedureConditionWrapper(cond, None)
-    assert not wrapper.satisfied
 
-    cond.update({'time': 100})
+    assert not wrapper.satisfied
     cond.update({'time': 101})
     assert wrapper.satisfied
 

--- a/application/tests/test_procedure_wrappers.py
+++ b/application/tests/test_procedure_wrappers.py
@@ -3,11 +3,12 @@ from ..procedure_wrappers import ProcedureStepsModel, ProcedureConditionWrapper
 
 
 def test_condition_wrapper_wraps_condition():
-    cond = top.WaitUntil(100)
+    cond = top.WaitFor(1)
 
     wrapper = ProcedureConditionWrapper(cond, None)
     assert not wrapper.satisfied
 
+    cond.update({'time': 100})
     cond.update({'time': 101})
     assert wrapper.satisfied
 

--- a/application/tests/test_procedures_bridge.py
+++ b/application/tests/test_procedures_bridge.py
@@ -47,7 +47,7 @@ def test_proc_bridge_procedure_controls_advance_procedure():
         top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
             (top.Immediate(), top.Transition('main', '2'))], 'PRIMARY'),
         top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [
-            (top.WaitUntil(100), top.Transition('main', '3'))], 'PRIMARY'),
+            (top.WaitFor(100), top.Transition('main', '3'))], 'PRIMARY'),
         top.ProcedureStep('3', top.MiscAction('Approach the launch tower'), [], 'SECONDARY')
     ])
 

--- a/topside/procedures/conditions.py
+++ b/topside/procedures/conditions.py
@@ -1,13 +1,17 @@
+from abc import ABC, abstractmethod
+
 import topside as top
 
 
-class Condition:
+class Condition(ABC):
     """
     Base class for all procedure conditions.
 
-    This class should never be used directly.
+    This class should never be used directly, so we make it an Abstract
+    Base Class (ABC) and mark all of the methods as abstract.
     """
 
+    @abstractmethod
     def reinitialize(self, state):
         """
         Re-initialize any data used by the condition.
@@ -18,25 +22,24 @@ class Condition:
         backwards, for example), we need a way of forgetting any data
         that conditions encountered the first time around.
         """
-        raise NotImplementedError('`reinitialize` must be implemented in derived Condition classes')
+        pass
 
+    @abstractmethod
     def update(self, state):
         """
         Update the condition with the state of the plumbing engine.
         """
-        raise NotImplementedError('`update` must be implemented in derived Condition classes')
+        pass
 
+    @abstractmethod
     def satisfied(self):
         """
         Return True if the condition is satisfied and False otherwise.
-
-        This is a purely virtual method and should be overridden in all
-        child classes.
         """
-        raise NotImplementedError('`satisfied` must be implemented in derived Condition classes')
+        pass
 
 
-class Immediate(Condition):
+class Immediate:
     """Condition that is always satisfied."""
 
     def __str__(self):
@@ -58,7 +61,7 @@ class Immediate(Condition):
         return type(other) == Immediate
 
 
-class And(Condition):
+class And:
     """
     Condition representing a logical AND of multiple other conditions.
     """
@@ -128,7 +131,7 @@ class And(Condition):
             raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
-class Or(Condition):
+class Or:
     """
     Condition representing a logical OR of multiple other conditions.
     """
@@ -198,7 +201,7 @@ class Or(Condition):
             raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
-class WaitFor(Condition):
+class WaitFor:
     """Condition that is satisfied once an amount of time has elapsed."""
 
     def __init__(self, wait_t):
@@ -209,9 +212,9 @@ class WaitFor(Condition):
         ----------
 
         wait_t: int
-            The wait time interval for this condition. This condition
-            will become satisfied `wait_t` after it first becomes active
-            (its step is reached).
+            The wait time interval for this condition, in microseconds.
+            This condition will become satisfied `wait_t` after it first
+            becomes active (its step is reached).
         """
         self.wait_t = wait_t
         self.current_t = None
@@ -268,7 +271,7 @@ class WaitFor(Condition):
             raise NotImplementedError(f'Format "{fmt}" not supported')
 
 
-class Comparison(Condition):
+class Comparison:
     """Base class for conditions comparing a pressure to a reference."""
 
     def __init__(self, node, pressure):

--- a/topside/procedures/procedures_engine.py
+++ b/topside/procedures/procedures_engine.py
@@ -69,6 +69,18 @@ class ProceduresEngine:
             if self._plumb is not None:
                 self._plumb.set_component_state(action.component, action.state)
 
+    def reinitialize_conditions(self):
+        """
+        Re-initialize all current conditions by querying the managed plumbing engine.
+        """
+        if self._plumb is not None and self.current_step is not None:
+            time = self._plumb.time
+            pressures = self._plumb.current_pressures()
+            state = {'time': time, 'pressures': pressures}
+
+            for condition, _ in self.current_step.conditions:
+                condition.reinitialize(state)
+
     def update_conditions(self):
         """
         Update all current conditions by querying the managed plumbing engine.
@@ -93,6 +105,7 @@ class ProceduresEngine:
 
         self.execute(self.current_step.action)
         self.step_position = StepPosition.After
+        self.reinitialize_conditions()
 
     def ready_to_proceed(self):
         """

--- a/topside/procedures/proclang.py
+++ b/topside/procedures/proclang.py
@@ -34,14 +34,14 @@ transition: name "." step_id
 
 condition: "[" boolean_expr "]"
 
-waituntil: time "s"
+waitfor: time "s"
 time: NUMBER
 
 boolean_expr: boolean_expr_and ( logic_or boolean_expr_and )*
 
 boolean_expr_and: boolean ( logic_and boolean )*
 
-boolean: waituntil
+boolean: waitfor
     | node operator value
     | "(" boolean_expr ")"
 
@@ -120,7 +120,7 @@ class ProcedureTransformer(Transformer):
 
         `data` is a list of either:
             - three elements, of the form [node, operator, reference]
-            - one WaitUntil element
+            - one WaitFor element
             - one boolean_expr element, which was wrapped in parentheses in the
               text
          """
@@ -129,7 +129,7 @@ class ProcedureTransformer(Transformer):
             # Must be a [node, operator, reference] type
             comp_class = data[1]
             return comp_class(data[0], data[2])
-        elif len(data) == 1 and type(data[0]) == top.WaitUntil:
+        elif len(data) == 1 and type(data[0]) == top.WaitFor:
             return data[0]
         elif len(data) == 1:
             # Assume that this is a parenthesized expression
@@ -159,14 +159,14 @@ class ProcedureTransformer(Transformer):
         else:
             return top.And(data)
 
-    def waituntil(self, data):
+    def waitfor(self, data):
         """
-        Process `waituntil` nodes in the parse tree.
+        Process `waitfor` nodes in the parse tree.
 
         `data` is a list of the form [reference_time]. reference_time is
         in seconds, so we need to convert it to microseconds.
         """
-        return top.WaitUntil(data[0] * 1e6)
+        return top.WaitFor(data[0] * 1e6)
 
     def condition(self, data):
         """

--- a/topside/procedures/tests/test_conditions.py
+++ b/topside/procedures/tests/test_conditions.py
@@ -19,37 +19,37 @@ def test_immediate_equality():
     assert cond1 is not None
 
 
-def test_wait_until_condition_exact():
-    cond = top.WaitUntil(100)
-    state = {'time': 100}
+def test_wait_for_condition_exact():
+    cond = top.WaitFor(100)
 
     assert cond.satisfied() is False
-    cond.update(state)
+    cond.update({'time': 0})
+    cond.update({'time': 100})
     assert cond.satisfied() is True
 
 
-def test_wait_until_condition_before():
-    cond = top.WaitUntil(100)
-    state = {'time': 99}
+def test_wait_for_condition_before():
+    cond = top.WaitFor(100)
 
     assert cond.satisfied() is False
-    cond.update(state)
+    cond.update({'time': 0})
+    cond.update({'time': 99})
     assert cond.satisfied() is False
 
 
-def test_wait_until_condition_after():
-    cond = top.WaitUntil(100)
-    state = {'time': 101}
+def test_wait_for_condition_after():
+    cond = top.WaitFor(100)
 
     assert cond.satisfied() is False
-    cond.update(state)
+    cond.update({'time': 0})
+    cond.update({'time': 101})
     assert cond.satisfied() is True
 
 
-def test_wait_until_equality():
-    cond1 = top.WaitUntil(100)
-    cond2 = top.WaitUntil(100)
-    cond3 = top.WaitUntil(200)
+def test_wait_for_equality():
+    cond1 = top.WaitFor(100)
+    cond2 = top.WaitFor(100)
+    cond3 = top.WaitFor(200)
 
     assert cond1 == cond2
     assert cond1 != cond3
@@ -385,7 +385,7 @@ def test_and_or_not_equal():
 
 def test_string_representations():
     immediate_cond = top.Immediate()
-    waitUntil_cond = top.WaitUntil(1000000)
+    waitFor_cond = top.WaitFor(1000000)
     equal_cond = top.Equal('A1', 100)
     less_cond = top.Less('A2', 100)
     greater_cond = top.Greater('A3', 100)
@@ -395,7 +395,7 @@ def test_string_representations():
     or_cond = top.Or([lessEqual_cond, greaterEqual_cond])
 
     assert str(immediate_cond) == 'Immediately'
-    assert str(waitUntil_cond) == 'Wait until 1 seconds'
+    assert str(waitFor_cond) == 'Wait for 1 seconds'
     assert str(equal_cond) == 'A1 == 100'
     assert str(less_cond) == 'A2 < 100'
     assert str(greater_cond) == 'A3 > 100'

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -50,11 +50,11 @@ def test_procedure_suite_latex_export():
     assert export == expected_export
 
 
-def test_waituntil_latex_export():
+def test_waitfor_latex_export():
     suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-                (top.WaitUntil(10e6), top.Transition('main', '2'))
+                (top.WaitFor(10e6), top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')
         ])
@@ -87,11 +87,11 @@ def test_proclang_file_latex_export():
     assert export == expected_export
 
 
-def test_waituntil_latex_export():
+def test_waitfor_latex_export():
     suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-                (top.And([top.WaitUntil(10e6), top.Or([top.Less('p1', 400.0),
+                (top.And([top.WaitFor(10e6), top.Or([top.Less('p1', 400.0),
                                                        top.GreaterEqual('p2', 17.0)])]), top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')

--- a/topside/procedures/tests/test_latex_export.py
+++ b/topside/procedures/tests/test_latex_export.py
@@ -90,10 +90,12 @@ def test_proclang_file_latex_export():
 def test_waitfor_latex_export():
     suite = top.ProcedureSuite([
         top.Procedure('main', [
-            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-                (top.And([top.WaitFor(10e6), top.Or([top.Less('p1', 400.0),
-                                                       top.GreaterEqual('p2', 17.0)])]), top.Transition('main', '2'))
-            ], 'PRIMARY'),
+            top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [(
+                top.And([top.WaitFor(10e6),
+                         top.Or([top.Less('p1', 400.0),
+                                 top.GreaterEqual('p2', 17.0)])]),
+                top.Transition('main', '2')
+            )], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')
         ])
     ])

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -310,8 +310,6 @@ def test_update_conditions_updates_time():
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
     proc_eng.execute_current()
 
-    proc_eng.update_conditions()
-
     assert proc_eng.ready_to_proceed() is False
 
     plumb_eng.step(10)
@@ -373,3 +371,27 @@ def test_reset():
     assert proc_eng.current_procedure_id == 'p1'
     assert proc_eng.current_step.step_id == 's1'
     assert plumb_eng.current_state('c1') == 'open'
+
+
+def test_reset_clears_conditions():
+    plumb_eng = one_component_engine()
+    plumb_eng.set_component_state('c1', 'open')
+
+    s1 = top.ProcedureStep('s1', None, [(top.WaitFor(10), 's2')], 'PRIMARY')
+    proc = top.Procedure('p1', [s1])
+    proc_suite = top.ProcedureSuite([proc], 'p1')
+
+    proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
+    proc_eng.execute_current()
+
+    assert proc_eng.ready_to_proceed() is False
+
+    plumb_eng.step(10)
+    proc_eng.update_conditions()
+
+    assert proc_eng.ready_to_proceed() is True
+
+    proc_eng.reset()
+    proc_eng.execute_current()
+
+    assert proc_eng.ready_to_proceed() is False

--- a/topside/procedures/tests/test_procedures_engine.py
+++ b/topside/procedures/tests/test_procedures_engine.py
@@ -303,21 +303,18 @@ def test_update_conditions_updates_time():
     plumb_eng = one_component_engine()
     plumb_eng.set_component_state('c1', 'open')
 
-    s1 = top.ProcedureStep('s1', None, [(top.WaitUntil(1e6), 's2')], 'PRIMARY')
+    s1 = top.ProcedureStep('s1', None, [(top.WaitFor(10), 's2')], 'PRIMARY')
     proc = top.Procedure('p1', [s1])
     proc_suite = top.ProcedureSuite([proc], 'p1')
 
     proc_eng = top.ProceduresEngine(plumb_eng, proc_suite)
     proc_eng.execute_current()
 
-    assert proc_eng.ready_to_proceed() is False
-
-    plumb_eng.step(1e6 - 1)
     proc_eng.update_conditions()
 
     assert proc_eng.ready_to_proceed() is False
 
-    plumb_eng.step(1)
+    plumb_eng.step(10)
     proc_eng.update_conditions()
 
     assert proc_eng.ready_to_proceed() is True

--- a/topside/procedures/tests/test_proclang.py
+++ b/topside/procedures/tests/test_proclang.py
@@ -139,7 +139,7 @@ def test_parse_two_procedures():
     assert suite == expected_suite
 
 
-def test_parse_step_with_waituntil():
+def test_parse_step_with_waitfor():
     proclang = '''
     main:
         1. PRIMARY: set injector_valve to open
@@ -150,7 +150,7 @@ def test_parse_step_with_waituntil():
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
-                (top.WaitUntil(10e6), top.Transition('main', '2'))
+                (top.WaitFor(10e6), top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')
         ])
@@ -231,7 +231,7 @@ def test_parse_step_with_two_deviations():
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
                 (top.Less('p1', 500), top.Transition('abort', '1')),
-                (top.WaitUntil(300e6), top.Transition('abort', '2')),
+                (top.WaitFor(300e6), top.Transition('abort', '2')),
                 (top.Immediate(), top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'PRIMARY')
@@ -255,7 +255,7 @@ def test_whitespace_is_irrelevant():
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('injector_valve', 'open'), [
                 (top.Less('p1', 500), top.Transition('abort', '1')),
-                (top.WaitUntil(300e6), top.Transition('abort', '2')),
+                (top.WaitFor(300e6), top.Transition('abort', '2')),
                 (top.Immediate(), top.Transition('main', '2'))
             ], 'CONTROL'),
             top.ProcedureStep('2', top.StateChangeAction('vent_valve', 'closed'), [], 'CONTROL')
@@ -315,7 +315,7 @@ def test_parse_from_file():
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('series_fill_valve', 'closed'), [
-                (top.WaitUntil(5e6), top.Transition('main', '2'))
+                (top.WaitFor(5e6), top.Transition('main', '2'))
             ], 'PRIMARY'),
             top.ProcedureStep('2', top.StateChangeAction('supply_valve', 'open'), [
                 (top.Less('p1', 600), top.Transition('abort_1', '1')),
@@ -326,7 +326,7 @@ def test_parse_from_file():
                 (top.Immediate(), top.Transition('main', '4'))
             ], 'PRIMARY'),
             top.ProcedureStep('4', top.StateChangeAction('remote_fill_valve', 'open'), [
-                (top.WaitUntil(180e6), top.Transition('main', '5'))
+                (top.WaitFor(180e6), top.Transition('main', '5'))
             ], 'PRIMARY'),
             top.ProcedureStep('5', top.StateChangeAction('remote_fill_valve', 'closed'), [
                 (top.Immediate(), top.Transition('main', '6'))
@@ -338,7 +338,7 @@ def test_parse_from_file():
         ]),
         top.Procedure('abort_1', [
             top.ProcedureStep('1', top.StateChangeAction('supply_valve', 'closed'), [
-                (top.WaitUntil(10e6), top.Transition('abort_1', '2'))
+                (top.WaitFor(10e6), top.Transition('abort_1', '2'))
             ], 'SECONDARY'),
             top.ProcedureStep('2', top.StateChangeAction('remote_vent_valve', 'open'), [
                 (top.Immediate(), top.Transition('abort_1', '3'))
@@ -492,7 +492,7 @@ def test_parse_combined_conditions():
 
     suite = top.proclang.parse(proclang)
 
-    comp_or = top.Or([top.Less('p1', 100), top.And([top.WaitUntil(1e6*500), top.Less('p2', 200)])])
+    comp_or = top.Or([top.Less('p1', 100), top.And([top.WaitFor(1e6*500), top.Less('p2', 200)])])
     expected_suite = top.ProcedureSuite([
         top.Procedure('main', [
             top.ProcedureStep('1', top.StateChangeAction('s', 'v'), [
@@ -525,7 +525,7 @@ def test_parse_misc_actions():
             ], 'CONTROL'),
             top.ProcedureStep('3', top.MiscAction(
                 'Approach the launch tower, disconnect the cylinder, and replace the cap'), [
-                (top.WaitUntil(60e6), top.Transition('main', '4'))
+                (top.WaitFor(60e6), top.Transition('main', '4'))
             ], 'PRIMARY'),
             top.ProcedureStep('4', top.MiscAction('Proceed with teardown'), [], 'OPS')
         ])

--- a/topside/procedures/tests/testing_utils.py
+++ b/topside/procedures/tests/testing_utils.py
@@ -1,4 +1,7 @@
-class NeverSatisfied:
+import topside as top
+
+
+class NeverSatisfied(top.Condition):
     def reinitialize(self, state):
         pass
 

--- a/topside/procedures/tests/testing_utils.py
+++ b/topside/procedures/tests/testing_utils.py
@@ -1,4 +1,7 @@
 class NeverSatisfied:
+    def reinitialize(self, state):
+        pass
+
     def update(self, state):
         pass
 


### PR DESCRIPTION
Instead of checking if a certain amount of time has elapsed since the
start of the procedure, WaitFor now checks if a certain amount of time
has elapsed since the most recent step was executed, which more
accurately represents the conditions we include in our procedures.

This is technically on the roadmap for W21, but I wanted to just get it out of the way so we can focus on the bigger things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/114)
<!-- Reviewable:end -->
