### PR TITLE
plumbing: Introduce node class as attribute

### DIFF
--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -175,11 +175,3 @@ def extract_edges(entry):
         edge_dict[edge_name] = (fwd_edge, back_edge)
 
     return edge_dict
-
-
-def instantiate_node(name, node_type=None):
-    """Instantiates a node of the given class with its name"""
-    if node_type is None:
-        return top.GenericNode(name)
-
-    return None

--- a/topside/pdl/parser.py
+++ b/topside/pdl/parser.py
@@ -175,3 +175,11 @@ def extract_edges(entry):
         edge_dict[edge_name] = (fwd_edge, back_edge)
 
     return edge_dict
+
+
+def instantiate_node(name, node_type=None):
+    """Instantiates a node of the given class with its name"""
+    if node_type is None:
+        return top.GenericNode(name)
+
+    return None

--- a/topside/plumbing/__init__.py
+++ b/topside/plumbing/__init__.py
@@ -3,3 +3,4 @@ from topside.plumbing.invalid_reasons import *
 from topside.plumbing.plumbing_component import *
 from topside.plumbing.plumbing_engine import *
 from topside.plumbing.plumbing_utils import *
+from topside.plumbing.node import *

--- a/topside/plumbing/node.py
+++ b/topside/plumbing/node.py
@@ -1,11 +1,17 @@
 from abc import ABC, abstractmethod
+
 import networkx as nx
 
 import topside.plumbing.plumbing_utils as utils
 
 
 def instantiate_node(type_id=None):
-    """Return the proper child node class depending on provided type_id."""
+    """
+    Return the proper child node class depending on provided type_id.
+
+    type_id should be a string that indicates the desired node type. If an unrecognized
+    string (or no string) is provided, we create a generic node.
+    """
     ret = None
     if type_id == utils.ATM:
         ret = AtmNode()

--- a/topside/plumbing/node.py
+++ b/topside/plumbing/node.py
@@ -21,22 +21,20 @@ class Node(ABC):
     Should never be used directly, so we tag all its methods as abstract.
     """
     @abstractmethod
-    # kwargs allowd for any additional arguments that need to be passed in
-    # to update the pressure
     def update_pressure(self, new_pressure, **kwargs):
-        pass
+        """Update pressure, kwargs are if additional params are needed."""
 
     @abstractmethod
     def get_pressure(self):
-        pass
+        """Return pressure."""
 
     @abstractmethod
     def update_fixed(self, fixed):
-        pass
+        """Change fixed value."""
 
     @abstractmethod
     def get_fixed(self):
-        pass
+        """Return fixed value."""
 
 
 class GenericNode(Node):

--- a/topside/plumbing/node.py
+++ b/topside/plumbing/node.py
@@ -5,6 +5,7 @@ import topside.plumbing.plumbing_utils as utils
 
 
 def instantiate_node(type_id=None):
+    """Return the proper child node class depending on provided type_id."""
     ret = None
     if type_id == utils.ATM:
         ret = AtmNode()
@@ -20,6 +21,8 @@ class Node(ABC):
     Should never be used directly, so we tag all its methods as abstract.
     """
     @abstractmethod
+    # kwargs allowd for any additional arguments that need to be passed in
+    # to update the pressure
     def update_pressure(self, new_pressure, **kwargs):
         pass
 
@@ -37,8 +40,12 @@ class Node(ABC):
 
 
 class GenericNode(Node):
+    """
+    A generic node, i.e. any node that doesn't require special consideration
+    in calculating its pressure.
+    """
+
     def __init__(self, pressure=0, fixed=False):
-        """Instantiate a generic node."""
         self.__pressure = pressure
         self.fixed = fixed
 
@@ -64,6 +71,8 @@ class GenericNode(Node):
 
 
 class AtmNode(Node):
+    """The atmosphere node."""
+
     def __str__(self):
         return f'[AtmNode] pressure: 0, fixed: True'
 
@@ -79,5 +88,6 @@ class AtmNode(Node):
     def get_fixed(self):
         return True
 
+    # All AtmNodes are equal, since they represent identical values
     def __eq__(self, other):
         return isinstance(other, AtmNode)

--- a/topside/plumbing/node.py
+++ b/topside/plumbing/node.py
@@ -1,0 +1,83 @@
+from abc import ABC, abstractmethod
+import networkx as nx
+
+import topside.plumbing.plumbing_utils as utils
+
+
+def instantiate_node(type_id=None):
+    ret = None
+    if type_id == utils.ATM:
+        ret = AtmNode()
+    else:
+        ret = GenericNode()
+    return ret
+
+
+class Node(ABC):
+    """
+    Abstract base class for all nodes.
+
+    Should never be used directly, so we tag all its methods as abstract.
+    """
+    @abstractmethod
+    def update_pressure(self, new_pressure, **kwargs):
+        pass
+
+    @abstractmethod
+    def get_pressure(self):
+        pass
+
+    @abstractmethod
+    def update_fixed(self, fixed):
+        pass
+
+    @abstractmethod
+    def get_fixed(self):
+        pass
+
+
+class GenericNode(Node):
+    def __init__(self, pressure=0, fixed=False):
+        """Instantiate a generic node."""
+        self.__pressure = pressure
+        self.fixed = fixed
+
+    def __str__(self):
+        return f'[GenericNode] pressure: {self.__pressure}, fixed: {self.fixed}'
+
+    def update_pressure(self, new_pressure, **kwargs):
+        self.__pressure = new_pressure
+
+    def get_pressure(self):
+        return self.__pressure
+
+    def update_fixed(self, fixed):
+        self.fixed = fixed
+
+    def get_fixed(self):
+        return self.fixed
+
+    def __eq__(self, other):
+        return isinstance(other, GenericNode) and \
+            self.__pressure == other.__pressure and \
+            self.fixed == other.fixed
+
+
+class AtmNode(Node):
+    def __str__(self):
+        return f'[AtmNode] pressure: 0, fixed: True'
+
+    def update_pressure(self, new_pressure, **kwargs):
+        pass
+
+    def get_pressure(self):
+        return 0
+
+    def update_fixed(self, fixed):
+        pass
+
+    def get_fixed(self):
+        return True
+
+    def __eq__(self, other):
+        return isinstance(other, AtmNode)

--- a/topside/plumbing/tests/test_node.py
+++ b/topside/plumbing/tests/test_node.py
@@ -1,0 +1,67 @@
+import pytest
+
+import topside as top
+import topside.plumbing.plumbing_utils as utils
+
+
+def test_generic_node():
+    node = top.GenericNode()
+    assert node.get_pressure() == 0
+    assert not node.get_fixed()
+
+    new_pressure = 100
+    node.update_pressure(new_pressure)
+
+    assert node.get_pressure() == new_pressure
+    assert not node.get_fixed()
+
+    node.update_fixed(True)
+    assert node.get_pressure() == new_pressure
+    assert node.get_fixed()
+
+    # just make sure this doesn't error
+    node.__str__()
+
+
+def test_generic_equality():
+    pressure = 10
+    node = top.GenericNode(pressure, True)
+
+    same_node = top.GenericNode(pressure, True)
+    assert node == same_node
+
+    diff_pressure = top.GenericNode(0, True)
+    diff_fixed = top.GenericNode(pressure, False)
+    assert node != diff_pressure
+    assert node != diff_fixed
+
+    diff_type = top.AtmNode()
+    assert node != diff_type
+
+
+def test_atm_node():
+    node = top.AtmNode()
+    assert node.get_pressure() == 0
+    assert node.get_fixed()
+
+    new_pressure = 100
+    node.update_pressure(new_pressure)
+    assert node.get_pressure() == 0
+    assert node.get_fixed()
+
+    node.update_fixed(False)
+    assert node.get_pressure() == 0
+    assert node.get_fixed()
+
+    # make sure this doesn't error
+    node.__str__()
+
+
+def test_atm_equality():
+    atm_node = top.AtmNode()
+    another_atm_node = top.AtmNode()
+
+    assert atm_node == another_atm_node
+
+    almost_atm_node = top.GenericNode(0, True)
+    assert atm_node != almost_atm_node

--- a/topside/plumbing/tests/test_node.py
+++ b/topside/plumbing/tests/test_node.py
@@ -6,13 +6,14 @@ import topside.plumbing.plumbing_utils as utils
 
 def test_instantiate_node():
     expected_atm_node = top.instantiate_node(utils.ATM)
-    atm_node = top.AtmNode()
-    assert type(expected_atm_node) == type(atm_node)
+    assert type(expected_atm_node) == top.AtmNode
 
     arbitrary_name = "name"
     expected_generic_node = top.instantiate_node(arbitrary_name)
-    generic_node = top.GenericNode()
-    assert type(expected_generic_node) == type(generic_node)
+    assert type(expected_generic_node) == top.GenericNode
+
+    no_name_node = top.instantiate_node()
+    assert type(no_name_node) == top.GenericNode
 
 
 def test_generic_node():

--- a/topside/plumbing/tests/test_node.py
+++ b/topside/plumbing/tests/test_node.py
@@ -4,6 +4,17 @@ import topside as top
 import topside.plumbing.plumbing_utils as utils
 
 
+def test_instantiate_node():
+    expected_atm_node = top.instantiate_node(utils.ATM)
+    atm_node = top.AtmNode()
+    assert type(expected_atm_node) == type(atm_node)
+
+    arbitrary_name = "name"
+    expected_generic_node = top.instantiate_node(arbitrary_name)
+    generic_node = top.GenericNode()
+    assert type(expected_generic_node) == type(generic_node)
+
+
 def test_generic_node():
     node = top.GenericNode()
     assert node.get_pressure() == 0

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -36,9 +36,6 @@ def test_open_closed_valves():
     assert plumb.current_state('valve2') == 'open'
 
 
-test_open_closed_valves()
-
-
 def test_arbitrary_states():
     plumb = test.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED, 0.5, 0.2, 10, utils.CLOSED)

--- a/topside/plumbing/tests/test_plumbing_engine_creation.py
+++ b/topside/plumbing/tests/test_plumbing_engine_creation.py
@@ -28,12 +28,15 @@ def test_open_closed_valves():
         (3, 2, 'valve2.B2', {'FC': utils.FC_MAX})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
+
+
+test_open_closed_valves()
 
 
 def test_arbitrary_states():
@@ -48,9 +51,9 @@ def test_arbitrary_states():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -73,9 +76,9 @@ def test_load_graph_to_empty():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -100,9 +103,9 @@ def test_replace_graph():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -570,9 +570,6 @@ def test_set_pressure_errors():
     plumb = test.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED, 0.5, 0.2, 10, utils.CLOSED)
 
-    for node in plumb.nodes():
-        print(node[1]['body'])
-
     pc = test.create_component(0, 0, 0, 1, 'valve3', 'C')
     mapping = {
         1: 3,

--- a/topside/plumbing/tests/test_plumbing_engine_editing.py
+++ b/topside/plumbing/tests/test_plumbing_engine_editing.py
@@ -25,8 +25,8 @@ def test_add_to_empty():
         (2, 1, 'valve.A2', {'FC': 0})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 20}),
-        (2, {'pressure': 0})
+        (1, {'body': top.GenericNode(20)}),
+        (2, {'body': top.GenericNode(0)})
     ]
     assert plumb.current_state('valve') == 'open'
 
@@ -54,10 +54,10 @@ def test_add_component():
         (4, 3, 'valve3.C2', {'FC': utils.teq_to_FC(utils.s_to_micros(1))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 50})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(50)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -229,10 +229,10 @@ def test_reset_keep_component():
         (4, 3, 'valve3.C2', {'FC': utils.teq_to_FC(utils.s_to_micros(1))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 0})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(0)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve3') == 'closed'
@@ -310,10 +310,10 @@ def test_reset_integration_and_keep_component():
         (4, 3, 'valve3.C2', {'FC': utils.teq_to_FC(utils.s_to_micros(1))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 0})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(0)})
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve3') == 'closed'
@@ -331,8 +331,8 @@ def test_remove_component():
         (2, 1, 'valve1.A2', {'FC': 0}),
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
     ]
     assert plumb.current_state('valve1') == 'closed'
 
@@ -367,9 +367,9 @@ def test_add_remove():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -415,9 +415,9 @@ def test_remove_add_errors():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))}),
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -467,8 +467,8 @@ def test_remove_errors_wrong_component_name():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0))}),
     ]
     assert plumb.nodes() == [
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
     ]
     assert plumb.current_state('valve2') == 'open'
 
@@ -487,9 +487,9 @@ def test_reverse_orientation():
         (3, 2, 'valve2.B2', {'FC': utils.teq_to_FC(utils.s_to_micros(0.2))})
     ]
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
     ]
     assert plumb.current_state('valve1') == 'closed'
     assert plumb.current_state('valve2') == 'open'
@@ -549,32 +549,37 @@ def test_set_pressure():
     plumb.set_pressure(2, 7000)
 
     assert plumb.nodes() == [
-        (1, {'pressure': 200}),
-        (2, {'pressure': 7000}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 50})
+        (1, {'body': top.GenericNode(200)}),
+        (2, {'body': top.GenericNode(7000)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(50)})
     ]
 
     plumb.set_pressure(4, 10)
     plumb.set_pressure(1, 0)
 
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 7000}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 10})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(7000)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(10)})
     ]
 
 
 def test_set_pressure_errors():
     plumb = test.two_valve_setup(
         0.5, 0.2, 10, utils.CLOSED, 0.5, 0.2, 10, utils.CLOSED)
+
+    for node in plumb.nodes():
+        print(node[1]['body'])
+
     pc = test.create_component(0, 0, 0, 1, 'valve3', 'C')
     mapping = {
         1: 3,
         2: 4
     }
     plumb.add_component(pc, mapping, 'closed', {4: (50, False)})
+
     pc_vent = test.create_component(0, 0, 0, 0, 'vent', 'D')
     mapping_vent = {
         1: 4,
@@ -593,11 +598,11 @@ def test_set_pressure_errors():
     assert str(err.value) == f"Pressure {not_a_number} must be a number."
 
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 50}),
-        (utils.ATM, {'pressure': 0})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(50)}),
+        (utils.ATM, {'body': top.AtmNode()})
     ]
 
     nonexistent_node = 5
@@ -607,11 +612,11 @@ def test_set_pressure_errors():
 
     plumb.set_pressure(4, 100)
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 100}),
-        (4, {'pressure': 100}),
-        (utils.ATM, {'pressure': 0})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(100)}),
+        (4, {'body': top.GenericNode(100)}),
+        (utils.ATM, {'body': top.AtmNode()})
     ]
 
     with pytest.raises(exceptions.BadInputError) as err:

--- a/topside/plumbing/tests/test_plumbing_engine_querying.py
+++ b/topside/plumbing/tests/test_plumbing_engine_querying.py
@@ -216,9 +216,9 @@ def test_list_functions():
 
     # Pressure at node 3 will be 0, since the provided one was invalid
     assert plumb.nodes() == [
-        (1, {'pressure': 0}),
-        (2, {'pressure': 0}),
-        (3, {'pressure': 0})
+        (1, {'body': top.GenericNode(0)}),
+        (2, {'body': top.GenericNode(0)}),
+        (3, {'body': top.GenericNode(0)}),
     ]
 
     assert plumb.nodes(data=False) == [1, 2, 3]


### PR DESCRIPTION
This introduces `Node` classes, which we use to model the various types of nodes in a plumbing graph - eg atmosphere, tanks with capacity, etc. The main purpose is to encapsulate the relevant attributes of a node in one place and to allow different pressure calculations to be done, depending on node type.

I was originally going to implement this through making the networkx nodes themselves objects, but that made identifying nodes fairly difficult. I was also worried about pass by reference errors and equality comparisons. Instead, the object is stored under a `body` attribute for each networkx node, and the nodes are still identified by their original names. 

A few parts could still use a little polishing, but I wanted to get the basic implementation in to unblock other people. Namely,
* determining what node type to return could still use a little work. It'll require PDL changes into the future, but since Kavin is working on the first non-trivial node type I figured it would be best to figure it out with him when he wants to start working on it.
* the `fixed_pressures` dict on the plumbing engine might not be as necessary anymore since nodes keep track of their own fixedness. That's just a code cleanup though, and can proceed in parallel with other work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/topside/123)
<!-- Reviewable:end -->
